### PR TITLE
Refactor marketing and auth pages to Tailwind styling

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,15 +1,33 @@
 import { Routes } from '@angular/router';
- 
-export const routes: Routes = [
-    
-    {path: "sales", 
-        loadComponent: ( )=> import('./pages/sales-page/sales-page.component').then(m => m.SalesPage)
-    },
-    {path: "storage", 
-        loadComponent: ( )=> import('./pages/storage-page/storage-page.component').then(m => m.StoragePage)
-    },
-    {path: "", 
-        loadComponent: ( )=> import('./pages/landing-page/landing-page.component').then(m => m.LandingPage)
-    }
 
+export const routes: Routes = [
+  {
+    path: '',
+    loadComponent: () => import('./pages/marketing-landing/marketing-landing.component').then(m => m.MarketingLandingPage)
+  },
+  {
+    path: 'login',
+    loadComponent: () => import('./pages/login-page/login-page.component').then(m => m.LoginPageComponent)
+  },
+  {
+    path: 'sign-up',
+    loadComponent: () => import('./pages/sign-up-page/sign-up-page.component').then(m => m.SignUpPageComponent)
+  },
+  {
+    path: 'app',
+    loadComponent: () => import('./pages/landing-page/landing-page.component').then(m => m.LandingPage)
+  },
+  {
+    path: 'sales',
+    loadComponent: () => import('./pages/sales-page/sales-page.component').then(m => m.SalesPage)
+  },
+  {
+    path: 'storage',
+    loadComponent: () => import('./pages/storage-page/storage-page.component').then(m => m.StoragePage)
+  },
+  {
+    path: '**',
+    redirectTo: '',
+    pathMatch: 'full'
+  }
 ];

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -1,35 +1,52 @@
-<!-- nav.component.html -->
-<nav class="nav flex gap-4 items-center justify-center bg-white border-b border-gray-200 px-6 py-4 shadow-sm">
-  <a
-    routerLink="/"
-    routerLinkActive="text-green-600 font-semibold"
-    class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
-  >
-    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0h6" />
-    </svg>
-    Main
-  </a>
-
-  <a
-    routerLink="/sales"
-    routerLinkActive="text-green-600 font-semibold"
-    class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
-  >
-    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path d="M4 4h16v4H4zM4 10h16v10H4z" />
-    </svg>
-    Sales
-  </a>
-
-  <a
-    routerLink="/storage"
-    routerLinkActive="text-green-600 font-semibold"
-    class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
-  >
-    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path d="M3 7l9-4 9 4v13a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
-    </svg>
-    Storage
-  </a>
+<nav class="sticky top-0 z-30 border-b border-slate-200/60 bg-white/90 backdrop-blur">
+  <div class="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-3 sm:flex-row sm:items-center sm:justify-between lg:px-8">
+    <div class="flex flex-wrap items-center gap-2 text-sm font-semibold text-slate-700">
+      <a
+        routerLink="/"
+        routerLinkActive="text-teal-800"
+        [routerLinkActiveOptions]="{ exact: true }"
+        #homeLink="routerLinkActive"
+        class="rounded-full px-3 py-1.5 transition hover:text-teal-800"
+        [class.bg-teal-50]="homeLink.isActive"
+      >
+        Home
+      </a>
+      <a
+        routerLink="/app"
+        routerLinkActive="text-teal-800"
+        #appLink="routerLinkActive"
+        class="rounded-full px-3 py-1.5 transition hover:text-teal-800"
+        [class.bg-teal-50]="appLink.isActive"
+      >
+        App Demo
+      </a>
+      <a
+        routerLink="/sales"
+        routerLinkActive="text-teal-800"
+        #salesLink="routerLinkActive"
+        class="rounded-full px-3 py-1.5 transition hover:text-teal-800"
+        [class.bg-teal-50]="salesLink.isActive"
+      >
+        Sales
+      </a>
+      <a
+        routerLink="/storage"
+        routerLinkActive="text-teal-800"
+        #storageLink="routerLinkActive"
+        class="rounded-full px-3 py-1.5 transition hover:text-teal-800"
+        [class.bg-teal-50]="storageLink.isActive"
+      >
+        Storage
+      </a>
+    </div>
+    <div class="flex items-center gap-3 text-sm font-semibold">
+      <a routerLink="/login" routerLinkActive="text-teal-800" class="text-slate-700 transition hover:text-teal-800">Log in</a>
+      <a
+        routerLink="/sign-up"
+        class="inline-flex items-center justify-center rounded-full bg-teal-800 px-4 py-2 text-white shadow-lg shadow-teal-800/30 transition hover:bg-teal-700"
+      >
+        Sign up
+      </a>
+    </div>
+  </div>
 </nav>

--- a/src/app/pages/login-page/login-page.component.html
+++ b/src/app/pages/login-page/login-page.component.html
@@ -1,0 +1,140 @@
+<section class="min-h-screen bg-slate-50 py-16 px-4 lg:px-8">
+  <div class="mx-auto flex max-w-6xl flex-col gap-12 lg:grid lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:items-start">
+    <div class="space-y-10">
+      <div class="space-y-4">
+        <span class="inline-flex items-center gap-2 rounded-full bg-teal-50 px-3 py-1 text-sm font-semibold text-teal-800">
+          <span class="h-2 w-2 rounded-full bg-teal-800"></span>
+          Welcome back to Hassib
+        </span>
+        <h1 class="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl lg:text-5xl">
+          Log in to your retail HQ
+        </h1>
+        <p class="max-w-xl text-lg leading-relaxed text-slate-600">
+          Access live sales dashboards, manage inventory and pick up right where your team left off.
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <span class="inline-flex items-center rounded-full border border-teal-100 bg-white px-3 py-1 text-sm font-medium text-teal-800 shadow-sm">
+            Real-time KPIs
+          </span>
+          <span class="inline-flex items-center rounded-full border border-teal-100 bg-white px-3 py-1 text-sm font-medium text-teal-800 shadow-sm">
+            POS integrations
+          </span>
+          <span class="inline-flex items-center rounded-full border border-teal-100 bg-white px-3 py-1 text-sm font-medium text-teal-800 shadow-sm">
+            Inventory alerts
+          </span>
+        </div>
+      </div>
+
+      <form
+        class="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/60 sm:p-8 lg:p-10"
+        (submit)="preventSubmit($event)"
+        novalidate
+      >
+        <div class="space-y-6">
+          <label class="block space-y-2">
+            <span class="text-sm font-semibold text-slate-700">Email address</span>
+            <input
+              type="email"
+              name="email"
+              class="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-900 shadow-inner focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-200"
+              placeholder="you@store.com"
+              autocomplete="email"
+              required
+            />
+          </label>
+
+          <label class="block space-y-2">
+            <span class="text-sm font-semibold text-slate-700">Password</span>
+            <div class="flex items-center gap-3 rounded-2xl border border-slate-200 bg-white px-4 py-3 shadow-inner focus-within:border-teal-500 focus-within:ring-4 focus-within:ring-teal-200">
+              <input
+                type="password"
+                name="password"
+                class="w-full border-none bg-transparent text-base text-slate-900 focus:outline-none"
+                placeholder="••••••••"
+                autocomplete="current-password"
+                required
+              />
+              <a routerLink="/reset" class="text-sm font-semibold text-teal-800 hover:text-teal-700">Forgot?</a>
+            </div>
+          </label>
+
+          <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <label class="flex items-center gap-3 text-sm text-slate-600">
+              <input type="checkbox" name="remember" class="h-4 w-4 rounded border-slate-300 text-teal-800 focus:ring-teal-500" />
+              Keep me signed in on this device
+            </label>
+            <button
+              type="submit"
+              class="inline-flex items-center justify-center rounded-full bg-teal-800 px-6 py-2.5 text-sm font-semibold tracking-wide text-white shadow-lg shadow-teal-800/30 transition hover:bg-teal-700"
+              disabled
+            >
+              Sign in
+            </button>
+          </div>
+
+          <p class="text-sm text-slate-600">
+            Don't have an account yet?
+            <a routerLink="/sign-up" class="font-semibold text-teal-800 hover:text-teal-700">Create one</a>.
+          </p>
+
+          <div class="relative flex items-center justify-center py-2 text-sm text-slate-500">
+            <span class="h-px w-full bg-slate-200"></span>
+            <span class="relative mx-4 bg-white px-2">Or continue with</span>
+            <span class="h-px w-full bg-slate-200"></span>
+          </div>
+
+          <div class="grid gap-3 sm:grid-cols-2">
+            <button
+              type="button"
+              class="inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:border-teal-200 hover:text-teal-800"
+              disabled
+            >
+              <svg class="h-5 w-5 text-slate-500" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  fill="currentColor"
+                  d="M21.8 10.2h-9v3.6h5.2a4.4 4.4 0 01-4.4 3.3 4.7 4.7 0 01-4.5-4.9 4.7 4.7 0 014.5-4.9 4.5 4.5 0 013.1 1.2l2.6-2.7A8 8 0 0012.2 3 8.4 8.4 0 003.5 11.4a8.5 8.5 0 008.7 8.6c4.6 0 8.1-3.1 8.1-8.4a9 9 0 00-.5-3.4z"
+                />
+              </svg>
+              Google
+            </button>
+            <button
+              type="button"
+              class="inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 transition hover:border-teal-200 hover:text-teal-800"
+              disabled
+            >
+              <svg class="h-5 w-5 text-slate-500" viewBox="0 0 24 24" aria-hidden="true">
+                <path
+                  fill="currentColor"
+                  d="M16.6 2c-.8.1-1.7.6-2.2 1.2-.5.5-.9 1.4-.8 2.3 1 0 2-.5 2.6-1.1.6-.6.9-1.4 1-2.4-.1 0-.3 0-.6 0zm3 6.3c-1.6-.1-3 1-3.8 1-1 0-2.4-1-3.9-1-2 0-3.9 1.2-4.9 3-2.1 3.6-.5 9.1 1.5 12.1 1 1.4 2.2 3 3.7 3 1.5 0 2-.9 3.7-.9s2.1.9 3.7.9c1.5 0 2.4-1.5 3.3-2.9 1-1.4 1.4-2.9 1.4-3-.1 0-2.7-1-2.7-3.9 0-2.5 2-3.6 2.1-3.7-1.3-1.9-3.2-2.1-3.8-2.2z"
+                />
+              </svg>
+              Apple
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+
+    <aside class="flex flex-col gap-6 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg shadow-slate-200/60 backdrop-blur sm:p-8 lg:p-10">
+      <div class="space-y-2">
+        <h2 class="text-2xl font-semibold text-slate-900">Getting started tips</h2>
+        <p class="text-sm text-slate-500">Make the most of your beta access with these quick pointers.</p>
+      </div>
+      <ul class="space-y-4">
+        @for (topic of helpTopics; track topic.title) {
+          <li class="rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+            <h3 class="text-base font-semibold text-slate-900">{{ topic.title }}</h3>
+            <p class="mt-1 text-sm text-slate-600">{{ topic.description }}</p>
+          </li>
+        }
+      </ul>
+      <div class="rounded-2xl border border-dashed border-teal-200 bg-teal-50/80 p-5 text-sm text-slate-700">
+        <h3 class="text-base font-semibold text-teal-800">Talk to support</h3>
+        <p class="mt-2 leading-relaxed">
+          Need immediate help? Reach our onboarding team at
+          <a href="mailto:support@hassib.app" class="font-semibold text-teal-800 hover:text-teal-700">support@hassib.app</a>.
+        </p>
+      </div>
+    </aside>
+  </div>
+</section>

--- a/src/app/pages/login-page/login-page.component.ts
+++ b/src/app/pages/login-page/login-page.component.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-login-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './login-page.component.html'
+})
+export class LoginPageComponent {
+  helpTopics = [
+    {
+      title: 'Need a workspace?',
+      description: 'Create a team space in seconds and invite your staff when you are ready.'
+    },
+    {
+      title: 'Forgot your password?',
+      description: 'Use the reset link below and we will email you the recovery steps instantly.'
+    },
+    {
+      title: 'Prefer social login?',
+      description: 'Sign in with Google or Apple once Supabase integration is connected.'
+    }
+  ];
+
+  preventSubmit(event: Event) {
+    event.preventDefault();
+  }
+}

--- a/src/app/pages/marketing-landing/marketing-landing.component.html
+++ b/src/app/pages/marketing-landing/marketing-landing.component.html
@@ -1,0 +1,192 @@
+<section class="relative overflow-hidden bg-slate-50">
+  <div class="absolute inset-0 bg-gradient-to-b from-white via-slate-50 to-slate-100"></div>
+  <div class="relative mx-auto flex max-w-6xl flex-col gap-12 px-4 py-20 lg:grid lg:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)] lg:px-8 lg:py-24">
+    <div class="space-y-8">
+      <span class="inline-flex items-center gap-2 rounded-full bg-teal-50 px-4 py-1 text-sm font-semibold text-teal-800">
+        <span class="h-2 w-2 rounded-full bg-teal-800"></span>
+        Retail OS for the GCC
+      </span>
+      <h1 class="text-4xl font-semibold tracking-tight text-slate-900 sm:text-5xl">
+        Transform your point of sale into a connected retail HQ
+      </h1>
+      <p class="max-w-2xl text-lg leading-relaxed text-slate-600">
+        Hassib brings sales, inventory and finance workflows together so your team always knows the next best move.
+        Built on Angular, ready for Supabase, loved by ambitious retailers.
+      </p>
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <a
+          routerLink="/sign-up"
+          class="inline-flex w-full items-center justify-center rounded-full bg-teal-800 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-teal-800/30 transition hover:bg-teal-700 sm:w-auto"
+        >
+          Create your account
+        </a>
+        <a
+          routerLink="/login"
+          class="inline-flex w-full items-center justify-center rounded-full border border-slate-200 bg-white px-6 py-3 text-sm font-semibold uppercase tracking-wide text-teal-800 shadow-sm transition hover:border-teal-200 hover:text-teal-700 sm:w-auto"
+        >
+          I already use Hassib
+        </a>
+      </div>
+      <p class="text-sm font-medium uppercase tracking-wide text-slate-500">
+        No credit card required • Early adopters get concierge onboarding
+      </p>
+    </div>
+
+    <div class="rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-xl shadow-slate-200/60 backdrop-blur sm:p-8 lg:p-10">
+      <div class="flex items-center justify-between">
+        <span class="text-sm font-semibold uppercase tracking-wide text-slate-500">Live sales snapshot</span>
+        <span class="rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-600">Preview</span>
+      </div>
+      <ul class="mt-6 grid gap-4 sm:grid-cols-3">
+        <li class="rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+          <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Today</span>
+          <p class="mt-2 text-2xl font-semibold text-slate-900">SAR 18,420</p>
+        </li>
+        <li class="rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+          <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Avg. basket</span>
+          <p class="mt-2 text-2xl font-semibold text-slate-900">SAR 216</p>
+        </li>
+        <li class="rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
+          <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Top category</span>
+          <p class="mt-2 text-2xl font-semibold text-slate-900">Home Fragrance</p>
+        </li>
+      </ul>
+      <div class="mt-8 grid grid-cols-5 items-end gap-2 rounded-2xl bg-gradient-to-br from-teal-50 via-white to-slate-50 p-4">
+        <div class="h-28 rounded-full bg-teal-100"></div>
+        <div class="h-36 rounded-full bg-teal-300"></div>
+        <div class="h-20 rounded-full bg-teal-100"></div>
+        <div class="h-40 rounded-full bg-teal-500"></div>
+        <div class="h-32 rounded-full bg-teal-200"></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="bg-white py-20 px-4 lg:px-8">
+  <div class="mx-auto max-w-5xl text-center">
+    <h2 class="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Why retail teams choose Hassib</h2>
+    <p class="mt-4 text-lg leading-relaxed text-slate-600">
+      Manage operations from cash reconciliation to inventory forecasting without leaving a single workspace.
+    </p>
+  </div>
+  <div class="mx-auto mt-12 grid max-w-6xl gap-6 md:grid-cols-3">
+    @for (feature of features; track feature.title) {
+      <article class="flex flex-col gap-3 rounded-3xl border border-slate-200 bg-slate-50/80 p-6 text-left shadow-sm">
+        <h3 class="text-xl font-semibold text-slate-900">{{ feature.title }}</h3>
+        <p class="text-sm leading-relaxed text-slate-600">{{ feature.description }}</p>
+      </article>
+    }
+  </div>
+</section>
+
+<section class="bg-slate-900 py-20 px-4 text-white lg:px-8">
+  <div class="mx-auto flex max-w-6xl flex-col gap-10 lg:grid lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] lg:items-center">
+    <div class="space-y-6">
+      <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">Built with modern tooling, ready for Supabase authentication</h2>
+      <p class="text-base leading-relaxed text-slate-200">
+        We engineered Hassib to plug directly into Supabase when you are ready. Authentication, row level security,
+        storage rules—everything is mapped for a smooth integration phase.
+      </p>
+      <ul class="space-y-3 text-sm leading-relaxed text-slate-200">
+        @for (item of highlights; track item) {
+          <li class="flex items-start gap-3 rounded-2xl border border-white/10 bg-white/5 p-3">
+            <svg class="mt-0.5 h-4 w-4 text-teal-200" viewBox="0 0 16 16" aria-hidden="true">
+              <path fill="currentColor" d="M6.1 11.5L2.6 8l1.1-1.1 2.4 2.4 6.2-6.2 1.1 1.1z" />
+            </svg>
+            {{ item }}
+          </li>
+        }
+      </ul>
+      <div class="flex flex-col gap-3 pt-4 sm:flex-row sm:items-center">
+        <a
+          routerLink="/app"
+          class="inline-flex w-full items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold uppercase tracking-wide text-teal-800 shadow-lg shadow-black/20 transition hover:bg-slate-100 sm:w-auto"
+        >
+          Explore the live demo
+        </a>
+        <span class="text-xs font-medium uppercase tracking-wide text-slate-300">
+          No setup required, data resets hourly.
+        </span>
+      </div>
+    </div>
+    <div class="rounded-3xl border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-transparent p-8 shadow-2xl shadow-black/30">
+      <div class="space-y-6">
+        <h3 class="text-lg font-semibold text-white">Supabase-ready architecture</h3>
+        <p class="text-sm leading-relaxed text-slate-200">
+          Auth routes, database schemas and storage policies align with Supabase defaults so your engineers can connect in
+          days instead of weeks.
+        </p>
+        <div class="grid gap-4 text-sm text-slate-100 sm:grid-cols-2">
+          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p class="font-semibold text-white">Auth scaffolding</p>
+            <p class="mt-1 text-xs text-slate-200">Pre-wired login &amp; sign-up views with social pathways.</p>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p class="font-semibold text-white">Row level security</p>
+            <p class="mt-1 text-xs text-slate-200">Policies mapped to retail roles to keep teams aligned.</p>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p class="font-semibold text-white">Realtime dashboards</p>
+            <p class="mt-1 text-xs text-slate-200">Angular 17 &amp; Material 3 powering responsive charts.</p>
+          </div>
+          <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+            <p class="font-semibold text-white">Offline ready</p>
+            <p class="mt-1 text-xs text-slate-200">PWA baseline with caching tuned for store networks.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="bg-white py-20 px-4 lg:px-8">
+  <div class="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)] lg:items-center">
+    <div class="space-y-4">
+      <h2 class="text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">Optimised for discoverability</h2>
+      <p class="text-base leading-relaxed text-slate-600">
+        Structured metadata and fast performance ensure Hassib is easy to find for retailers searching for modern POS
+        options. These SEO enhancements also power deep links into the product.
+      </p>
+    </div>
+    <div class="grid gap-4 sm:grid-cols-3">
+      <div class="rounded-3xl border border-slate-200 bg-slate-50/80 p-5 text-sm text-slate-600">
+        <h3 class="text-base font-semibold text-teal-800">Meta tags</h3>
+        <p class="mt-2 leading-relaxed">Rich OpenGraph &amp; Twitter cards help your store look premium when shared.</p>
+      </div>
+      <div class="rounded-3xl border border-slate-200 bg-slate-50/80 p-5 text-sm text-slate-600">
+        <h3 class="text-base font-semibold text-teal-800">Schema.org data</h3>
+        <p class="mt-2 leading-relaxed">Search engines understand Hassib as a platform thanks to JSON-LD markup.</p>
+      </div>
+      <div class="rounded-3xl border border-slate-200 bg-slate-50/80 p-5 text-sm text-slate-600">
+        <h3 class="text-base font-semibold text-teal-800">Lightning fast</h3>
+        <p class="mt-2 leading-relaxed">Angular hydration, lazy loaded routes and caching keep the experience crisp.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="bg-slate-900 py-20 px-4 text-white lg:px-8">
+  <div class="mx-auto flex max-w-5xl flex-col items-center gap-6 text-center">
+    <h2 class="text-3xl font-semibold tracking-tight sm:text-4xl">Ready to move faster?</h2>
+    <p class="max-w-3xl text-base leading-relaxed text-slate-200">
+      Join retailers across Riyadh, Jeddah and Dubai who already use Hassib to reconcile stock, manage teams and grow
+      omnichannel revenue.
+    </p>
+    <div class="flex w-full flex-col gap-3 sm:w-auto sm:flex-row">
+      <a
+        routerLink="/sign-up"
+        class="inline-flex w-full items-center justify-center rounded-full bg-white px-6 py-3 text-sm font-semibold uppercase tracking-wide text-teal-800 shadow-lg shadow-black/20 transition hover:bg-slate-100 sm:w-auto"
+      >
+        Book my onboarding
+      </a>
+      <a
+        routerLink="/login"
+        class="inline-flex w-full items-center justify-center rounded-full border border-white/30 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white transition hover:border-white hover:bg-white/10 sm:w-auto"
+      >
+        Sign in
+      </a>
+    </div>
+  </div>
+</section>
+
+<script type="application/ld+json" [innerHTML]="schemaMarkup"></script>

--- a/src/app/pages/marketing-landing/marketing-landing.component.ts
+++ b/src/app/pages/marketing-landing/marketing-landing.component.ts
@@ -1,0 +1,77 @@
+import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { DomSanitizer, Meta, Title } from '@angular/platform-browser';
+import { SafeHtml } from '@angular/platform-browser';
+
+@Component({
+  selector: 'app-marketing-landing',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './marketing-landing.component.html'
+})
+export class MarketingLandingPage {
+  private title = inject(Title);
+  private meta = inject(Meta);
+  private sanitizer = inject(DomSanitizer);
+
+  features = [
+    {
+      title: 'Sales, storage & reporting in one place',
+      description: 'Manage live POS operations, reconcile inventory and produce tax-ready reports in minutes.'
+    },
+    {
+      title: 'Supabase ready architecture',
+      description: 'Every screen is designed to plug directly into Supabase Auth, Database and Functions when you connect.'
+    },
+    {
+      title: 'Tailored for GCC retailers',
+      description: 'Arabic-enabled receipts, KSA VAT defaults and Mada-ready payment splits make onboarding smooth.'
+    }
+  ];
+
+  highlights = [
+    'Realtime dashboards built with Angular 17 and Material 3',
+    'Inventory calculators to forecast margins and tax exposure',
+    'Role-based access to keep finance teams and cashiers aligned',
+    'Works across tablet and desktop with offline support planned'
+  ];
+
+  schemaMarkup: SafeHtml;
+
+  constructor() {
+    this.title.setTitle('Hassib POS | Cloud Retail Platform for Modern Stores');
+    this.meta.addTags([
+      { name: 'description', content: 'Hassib gives retail teams a fast POS, real-time inventory analytics and ready-to-connect Supabase authentication.' },
+      { name: 'keywords', content: 'Hassib POS, retail inventory, GCC POS, Supabase, sales dashboard' },
+      { property: 'og:title', content: 'Hassib POS – Retail operations in one place' },
+      { property: 'og:description', content: 'Launch a modern POS with inventory management, VAT tools and Supabase-ready authentication.' },
+      { property: 'og:type', content: 'website' },
+      { property: 'og:url', content: 'https://app.hassib.dev/' },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'twitter:title', content: 'Hassib POS | Modern Retail HQ' },
+      { name: 'twitter:description', content: 'From sales to storage—Hassib centralises everything for ambitious retailers.' }
+    ], true);
+
+    const schema = {
+      '@context': 'https://schema.org',
+      '@type': 'SoftwareApplication',
+      name: 'Hassib POS',
+      applicationCategory: 'BusinessApplication',
+      operatingSystem: 'Web',
+      description: 'Hassib is a cloud-based POS and inventory management platform built for GCC retailers.',
+      offers: {
+        '@type': 'Offer',
+        availability: 'https://schema.org/PreOrder',
+        price: '0',
+        priceCurrency: 'USD'
+      },
+      creator: {
+        '@type': 'Organization',
+        name: 'Hassib'
+      }
+    };
+
+    this.schemaMarkup = this.sanitizer.bypassSecurityTrustHtml(JSON.stringify(schema));
+  }
+}

--- a/src/app/pages/sign-up-page/sign-up-page.component.html
+++ b/src/app/pages/sign-up-page/sign-up-page.component.html
@@ -1,0 +1,145 @@
+<section class="min-h-screen bg-slate-50 py-16 px-4 lg:px-8">
+  <div class="mx-auto max-w-5xl text-center">
+    <span class="inline-flex items-center justify-center gap-2 rounded-full bg-teal-50 px-4 py-1 text-sm font-semibold text-teal-800">
+      <span class="h-2 w-2 rounded-full bg-teal-800"></span>
+      Create your Hassib workspace
+    </span>
+    <h1 class="mt-6 text-3xl font-semibold tracking-tight text-slate-900 sm:text-4xl">
+      Start selling smarter in minutes
+    </h1>
+    <p class="mx-auto mt-4 max-w-2xl text-lg leading-relaxed text-slate-600">
+      Launch a cloud POS environment tailored for retail teams in the GCC. No credit card required during beta.
+    </p>
+  </div>
+
+  <div class="mx-auto mt-12 max-w-6xl gap-10 lg:mt-16 lg:grid lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
+    <form
+      class="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/60 sm:p-8 lg:p-10"
+      (submit)="preventSubmit($event)"
+      novalidate
+    >
+      <div class="space-y-6">
+        <label class="block space-y-2">
+          <span class="text-sm font-semibold text-slate-700">Store name</span>
+          <input
+            type="text"
+            name="store"
+            class="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-900 shadow-inner focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-200"
+            placeholder="Riyadh Flagship"
+            autocomplete="organization"
+            required
+          />
+        </label>
+
+        <div class="grid gap-6 sm:grid-cols-2">
+          <label class="block space-y-2">
+            <span class="text-sm font-semibold text-slate-700">Work email</span>
+            <input
+              type="email"
+              name="email"
+              class="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-900 shadow-inner focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-200"
+              placeholder="you@brand.com"
+              autocomplete="email"
+              required
+            />
+          </label>
+          <label class="block space-y-2">
+            <span class="text-sm font-semibold text-slate-700">Phone number</span>
+            <input
+              type="tel"
+              name="phone"
+              class="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-900 shadow-inner focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-200"
+              placeholder="05X XXX XXXX"
+              autocomplete="tel"
+            />
+          </label>
+        </div>
+
+        <label class="block space-y-2">
+          <span class="text-sm font-semibold text-slate-700">Password</span>
+          <input
+            type="password"
+            name="password"
+            class="w-full rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-900 shadow-inner focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-200"
+            placeholder="Create a strong password"
+            autocomplete="new-password"
+            required
+          />
+        </label>
+
+        <label class="block space-y-2">
+          <span class="text-sm font-semibold text-slate-700">Team size</span>
+          <select
+            name="team-size"
+            class="w-full appearance-none rounded-2xl border border-slate-200 bg-white px-4 py-3 text-base text-slate-900 shadow-inner focus:border-teal-500 focus:outline-none focus:ring-4 focus:ring-teal-200"
+          >
+            <option value="1-5">1 - 5 people</option>
+            <option value="6-20">6 - 20 people</option>
+            <option value="21-50">21 - 50 people</option>
+            <option value="51+">More than 50 people</option>
+          </select>
+        </label>
+
+        <fieldset class="rounded-2xl border border-slate-200 bg-slate-50/80 p-6">
+          <legend class="px-2 text-sm font-semibold uppercase tracking-wide text-teal-800">Select a launch plan</legend>
+          <div class="mt-4 grid gap-3 sm:grid-cols-3">
+            @for (plan of plans; track plan.name) {
+              <label class="flex cursor-pointer flex-col gap-2 rounded-2xl border border-transparent bg-white p-4 text-left shadow-sm transition hover:border-teal-200 hover:shadow-md">
+                <input type="radio" name="plan" [value]="plan.name" class="sr-only" />
+                <span class="text-base font-semibold text-slate-900">{{ plan.name }}</span>
+                <span class="text-sm text-slate-600">{{ plan.detail }}</span>
+              </label>
+            }
+          </div>
+        </fieldset>
+
+        <label class="flex items-start gap-3 text-sm text-slate-600">
+          <input type="checkbox" name="terms" required class="mt-1 h-4 w-4 rounded border-slate-300 text-teal-800 focus:ring-teal-500" />
+          <span>
+            I agree to the
+            <a routerLink="/terms" class="font-semibold text-teal-800 hover:text-teal-700">Terms of Service</a>
+            and
+            <a routerLink="/privacy" class="font-semibold text-teal-800 hover:text-teal-700">Privacy Policy</a>.
+          </span>
+        </label>
+
+        <button
+          type="submit"
+          class="inline-flex w-full items-center justify-center rounded-full bg-teal-800 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-white shadow-lg shadow-teal-800/30 transition hover:bg-teal-700"
+          disabled
+        >
+          Create my account
+        </button>
+        <p class="text-center text-sm text-slate-600">
+          Already have access?
+          <a routerLink="/login" class="font-semibold text-teal-800 hover:text-teal-700">Log in</a>.
+        </p>
+      </div>
+    </form>
+
+    <aside class="mt-10 flex flex-col gap-6 rounded-3xl border border-slate-200 bg-white/80 p-6 shadow-lg shadow-slate-200/60 backdrop-blur sm:p-8 lg:mt-0 lg:p-10">
+      <div class="inline-flex w-fit items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-amber-600">
+        Beta Access
+      </div>
+      <h2 class="text-2xl font-semibold text-slate-900">What's included today</h2>
+      <ul class="space-y-3 text-sm text-slate-700">
+        @for (item of checklist; track item) {
+          <li class="flex items-start gap-3 rounded-2xl border border-slate-100 bg-slate-50/80 p-3">
+            <svg class="mt-1 h-4 w-4 text-teal-800" viewBox="0 0 16 16" aria-hidden="true">
+              <path fill="currentColor" d="M6.1 11.5L2.6 8l1.1-1.1 2.4 2.4 6.2-6.2 1.1 1.1z" />
+            </svg>
+            {{ item }}
+          </li>
+        }
+      </ul>
+      <div class="rounded-2xl border border-dashed border-slate-200 p-5 text-left text-sm text-slate-600">
+        <h3 class="text-base font-semibold text-teal-800">Launch timeline</h3>
+        <ol class="mt-3 space-y-2">
+          <li><span class="font-semibold text-slate-900">Day 0</span> — Receive your invite and confirm your email</li>
+          <li><span class="font-semibold text-slate-900">Day 1</span> — Configure products and tax rates with guided setup</li>
+          <li><span class="font-semibold text-slate-900">Day 7</span> — Connect Supabase auth &amp; sync POS terminals</li>
+        </ol>
+      </div>
+    </aside>
+  </div>
+</section>

--- a/src/app/pages/sign-up-page/sign-up-page.component.ts
+++ b/src/app/pages/sign-up-page/sign-up-page.component.ts
@@ -1,0 +1,37 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-sign-up-page',
+  standalone: true,
+  imports: [CommonModule, RouterLink],
+  templateUrl: './sign-up-page.component.html'
+})
+export class SignUpPageComponent {
+  plans = [
+    {
+      name: 'Starter',
+      detail: 'Best for single-location retailers trying Hassib for the first time.'
+    },
+    {
+      name: 'Growth',
+      detail: 'Multi-branch teams who need inventory forecasting and user roles.'
+    },
+    {
+      name: 'Enterprise',
+      detail: 'Custom SLAs, dedicated support, and advanced analytics.'
+    }
+  ];
+
+  checklist = [
+    'Unlimited products and barcode scanning',
+    'Realtime sales and tax dashboards',
+    'Staff permissions with audit trails',
+    'Built-in Supabase authentication ready'
+  ];
+
+  preventSubmit(event: Event) {
+    event.preventDefault();
+  }
+}


### PR DESCRIPTION
## Summary
- restyle the marketing landing page with Tailwind utility classes, teal-focused accents, and responsive sections
- rebuild the login and sign-up forms with Tailwind-driven layouts, Supabase-ready helper content, and support cards
- switch the navigation bar to Tailwind utilities so all new surfaces share the same utility-first styling approach

## Testing
- npm run lint
- npm test *(fails: existing product-manager.component.spec.ts parse error from missing semicolon)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb4b549748324ad0a10879cc6092b