### PR TITLE
Revamp UI and improve SEO

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,14 @@
-<div class="overflow-x-hidden">
-<app-nav></app-nav> 
-<router-outlet></router-outlet>
+<div class="app-shell">
+  <app-nav></app-nav>
 
+  <main class="app-main" role="main">
+    <router-outlet></router-outlet>
+  </main>
+
+  <footer class="app-footer" role="contentinfo">
+    <div class="footer-inner">
+      <span class="footer-brand">Hassib POS Suite</span>
+      <span class="footer-copy">Built for fast retail operations and accurate inventory.</span>
+    </div>
+  </footer>
 </div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,0 +1,49 @@
+.app-shell {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: radial-gradient(circle at top left, rgba(14, 165, 233, 0.08), transparent 45%),
+              radial-gradient(circle at top right, rgba(16, 185, 129, 0.08), transparent 45%),
+              linear-gradient(180deg, rgba(248, 250, 252, 0.9), rgba(241, 245, 249, 0.85));
+}
+
+.app-main {
+  flex: 1;
+  padding: clamp(1.5rem, 3vw, 3rem) clamp(1rem, 4vw, 4rem);
+  display: flex;
+  flex-direction: column;
+}
+
+@media (max-width: 900px) {
+  .app-main {
+    padding: clamp(1.25rem, 6vw, 2.25rem) clamp(1rem, 6vw, 2.25rem);
+  }
+}
+
+.app-footer {
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+  padding: 1.25rem clamp(1rem, 4vw, 4rem);
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(12px);
+}
+
+.footer-inner {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.footer-brand {
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.9);
+}
+
+@media (min-width: 768px) {
+  .footer-inner {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+}

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -4,7 +4,8 @@ import { NavComponent } from './components/navbar/navbar.component';
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet,NavComponent],
-  templateUrl: './app.component.html'
+  imports: [RouterOutlet, NavComponent],
+  templateUrl: './app.component.html',
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {}

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -1,35 +1,57 @@
-<!-- nav.component.html -->
-<nav class="nav flex gap-4 items-center justify-center bg-white border-b border-gray-200 px-6 py-4 shadow-sm">
-  <a
-    routerLink="/"
-    routerLinkActive="text-green-600 font-semibold"
-    class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
-  >
-    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0h6" />
-    </svg>
-    Main
-  </a>
+<nav class="top-nav" aria-label="Primary navigation">
+  <div class="nav-inner">
+    <a class="brand" routerLink="/" (click)="closeMenu()">
+      <span class="brand-mark" aria-hidden="true">H</span>
+      <span class="brand-copy">
+        <span class="brand-title">Hassib</span>
+        <span class="brand-subtitle">POS &amp; Inventory Hub</span>
+      </span>
+    </a>
 
-  <a
-    routerLink="/sales"
-    routerLinkActive="text-green-600 font-semibold"
-    class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
-  >
-    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path d="M4 4h16v4H4zM4 10h16v10H4z" />
-    </svg>
-    Sales
-  </a>
+    <button
+      type="button"
+      class="menu-toggle"
+      (click)="toggleMenu()"
+      [attr.aria-expanded]="menuOpen()"
+      aria-controls="primary-navigation"
+    >
+      <span class="sr-only">Toggle navigation</span>
+      <svg aria-hidden="true" class="icon" viewBox="0 0 24 24">
+        <path
+          [attr.d]="menuOpen() ? 'M6 6L18 18M6 18L18 6' : 'M4 6h16M4 12h16M4 18h16'"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </button>
 
-  <a
-    routerLink="/storage"
-    routerLinkActive="text-green-600 font-semibold"
-    class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
-  >
-    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path d="M3 7l9-4 9 4v13a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
-    </svg>
-    Storage
-  </a>
+    <div class="nav-links" [class.open]="menuOpen()" id="primary-navigation">
+      <a
+        routerLink="/"
+        routerLinkActive="active"
+        class="nav-link"
+        (click)="closeMenu()"
+      >
+        Overview
+      </a>
+      <a
+        routerLink="/sales"
+        routerLinkActive="active"
+        class="nav-link"
+        (click)="closeMenu()"
+      >
+        Sales Workspace
+      </a>
+      <a
+        routerLink="/storage"
+        routerLinkActive="active"
+        class="nav-link"
+        (click)="closeMenu()"
+      >
+        Inventory
+      </a>
+    </div>
+  </div>
 </nav>

--- a/src/app/components/navbar/navbar.component.scss
+++ b/src/app/components/navbar/navbar.component.scss
@@ -1,0 +1,152 @@
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 40;
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 8px 18px -14px rgba(15, 23, 42, 0.45);
+}
+
+.nav-inner {
+  margin: 0 auto;
+  max-width: 1200px;
+  padding: 0.9rem clamp(1rem, 4vw, 3rem);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  text-decoration: none;
+}
+
+.brand-mark {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.8rem;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: 1.125rem;
+  background: linear-gradient(135deg, #0ea5a4, #0f766e);
+  color: #fff;
+  box-shadow: 0 10px 30px -15px rgba(15, 118, 110, 0.75);
+}
+
+.brand-title {
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: rgba(15, 23, 42, 0.92);
+}
+
+.brand-subtitle {
+  font-size: 0.78rem;
+  color: rgba(15, 23, 42, 0.55);
+  letter-spacing: 0.02em;
+}
+
+.menu-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: #fff;
+  color: rgba(15, 23, 42, 0.7);
+  transition: all 0.2s ease;
+}
+
+.menu-toggle:hover,
+.menu-toggle:focus-visible {
+  border-color: rgba(14, 165, 233, 0.55);
+  color: rgba(14, 165, 233, 0.9);
+  outline: none;
+}
+
+.icon {
+  width: 1.4rem;
+  height: 1.4rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.55rem 0.9rem;
+  border-radius: 0.75rem;
+  color: rgba(15, 23, 42, 0.7);
+  font-weight: 500;
+  text-decoration: none;
+  transition: all 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+  color: rgba(14, 116, 144, 0.95);
+  background: rgba(14, 165, 233, 0.1);
+  outline: none;
+}
+
+.nav-link.active {
+  color: rgba(15, 23, 42, 0.95);
+  background: rgba(20, 184, 166, 0.16);
+  box-shadow: inset 0 0 0 1px rgba(20, 184, 166, 0.35);
+}
+
+@media (max-width: 900px) {
+  .nav-inner {
+    flex-wrap: wrap;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+
+  .nav-links {
+    flex-direction: column;
+    width: 100%;
+    padding-top: 0.75rem;
+    border-top: 1px solid rgba(15, 23, 42, 0.08);
+    margin-top: 0.75rem;
+    display: none;
+  }
+
+  .nav-links.open {
+    display: flex;
+  }
+
+  .nav-link {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (min-width: 901px) {
+  .menu-toggle {
+    display: none;
+  }
+}

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 
@@ -7,5 +7,16 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [CommonModule, RouterModule],
   templateUrl: './navbar.component.html',
+  styleUrls: ['./navbar.component.scss']
 })
-export class NavComponent {}
+export class NavComponent {
+  menuOpen = signal(false);
+
+  toggleMenu() {
+    this.menuOpen.update((state) => !state);
+  }
+
+  closeMenu() {
+    this.menuOpen.set(false);
+  }
+}

--- a/src/app/components/sale-table/sale-table.component.html
+++ b/src/app/components/sale-table/sale-table.component.html
@@ -1,10 +1,9 @@
-<!-- ✅ Responsive Table Wrapper: scroll on small screens only -->
-<div class="w-full overflow-x-auto">
-  <table class="w-full text-sm min-w-max" aria-live="polite">
+<div class="table-scroll">
+  <table class="data-table" aria-live="polite">
     <thead>
       <tr>
         @for (col of columns; track col.key) {
-          <th class="text-left px-2 py-1 whitespace-nowrap">{{ col.label }}</th>
+          <th>{{ col.label }}</th>
         }
       </tr>
     </thead>
@@ -13,7 +12,7 @@
       @for (ln of lines(); track $index; let i = $index) {
         <tr>
           @for (col of columns; track col.key) {
-            <td class="px-2 py-1 whitespace-nowrap" [class]="col.class">
+            <td [class]="col.class">
               {{ col.format ? col.format(ln, i) : '' }}
             </td>
           }
@@ -25,16 +24,16 @@
       @for (footerRow of [0, 1]; track $index; let r = $index) {
         <tr>
           @if (r === 0) {
-            <td colspan="3" class="px-2 py-1 font-semibold">Totals</td>
-            <td class="px-2 py-1">{{ totalQty() }}</td>
-            <td class="px-2 py-1">SAR {{ totalCost() | number:'1.2-2' }}</td>
-            <td class="px-2 py-1">SAR {{ totalGross() | number:'1.2-2' }}</td>
-            <td class="px-2 py-1">SAR {{ totalVAT() | number:'1.2-2' }}</td>
-            <td class="px-2 py-1">SAR {{ totalProfit() | number:'1.2-2' }}</td>
+            <td colspan="3">Totals</td>
+            <td>{{ totalQty() }}</td>
+            <td>SAR {{ totalCost() | number:'1.2-2' }}</td>
+            <td>SAR {{ totalGross() | number:'1.2-2' }}</td>
+            <td>SAR {{ totalVAT() | number:'1.2-2' }}</td>
+            <td>SAR {{ totalProfit() | number:'1.2-2' }}</td>
             <td colspan="2"></td>
           } @else {
             <td colspan="4"></td>
-            <td colspan="6" class="text-left px-2 py-1">
+            <td colspan="6" class="payment-break">
               <strong>By Payment:</strong> {{ paymentBreakdownText() }}
             </td>
           }

--- a/src/app/components/session-summary/session-summary.component.html
+++ b/src/app/components/session-summary/session-summary.component.html
@@ -1,31 +1,38 @@
-<h3 style="margin:6px 0">Session Summary</h3>
+<section class="summary-card">
+  <header class="summary-header">
+    <h2>Session overview</h2>
+    <p class="muted">Track totals as you register each item. Export options appear below.</p>
+  </header>
 
-@if (lines().length > 0) {
-  <div #reportRoot>
-    <div class="summary">
-      @for (m of metrics(); track m.label) {
-        <div class="metric">
-          <span class="small">{{ m.label }}</span>
-          <span>{{ m.value() }}</span>
-        </div>
+  @if (lines().length > 0) {
+    <div #reportRoot>
+      <div class="summary-grid">
+        @for (m of metrics(); track m.label) {
+          <div class="summary-metric">
+            <span class="summary-label">{{ m.label }}</span>
+            <span class="summary-value">{{ m.value() }}</span>
+          </div>
+        }
+      </div>
+
+      <div class="summary-breakdown">
+        <span class="summary-label">Payment mix</span>
+        <span class="muted">{{ paymentBreakdownText() }}</span>
+      </div>
+    </div>
+
+    <div class="summary-actions">
+      @for (a of actions(); track a.key) {
+        <button class="{{ a.css }}" (click)="a.run()">{{ a.label }}</button>
       }
     </div>
-
-    <div style="margin-top:10px">
-      <div class="small">Payment Breakdown</div>
-      <div class="payment-break">{{ paymentBreakdownText() }}</div>
+  } @else {
+    <div class="summary-empty">
+      <p>No session lines yet. Start by adding products on the left.</p>
     </div>
-  </div>
+  }
 
-  <div class="actions">
-    @for (a of actions(); track a.key) {
-      <button class="{{ a.css }}" (click)="a.run()">{{ a.label }}</button>
-    }
-  </div>
-} @else {
-  <div class="small" style="color:var(--muted)">No session lines yet.</div>
-}
-
-<div class="footer-note small mobile-hide">
-  Tip: Use the export as a quick record at shift-end. No data leaves your device unless you choose to share.
-</div>
+  <footer class="summary-footer">
+    <small>Tip: exports stay on your device until you choose to share them.</small>
+  </footer>
+</section>

--- a/src/app/components/session-summary/session-summary.component.scss
+++ b/src/app/components/session-summary/session-summary.component.scss
@@ -1,0 +1,88 @@
+.summary-card {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.summary-header h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+.summary-header p {
+  margin: 0;
+}
+
+.summary-grid {
+  display: grid;
+  gap: 0.85rem;
+}
+
+@media (min-width: 520px) {
+  .summary-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.summary-metric {
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.9rem;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 18px 30px -28px rgba(15, 23, 42, 0.45);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.summary-label {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(15, 23, 42, 0.5);
+}
+
+.summary-value {
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.summary-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.8rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px dashed rgba(15, 23, 42, 0.12);
+  background: rgba(248, 250, 252, 0.75);
+}
+
+.summary-actions {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.summary-empty {
+  padding: 0.9rem 1rem;
+  border-radius: 0.9rem;
+  background: rgba(248, 250, 252, 0.8);
+  border: 1px dashed rgba(15, 23, 42, 0.12);
+}
+
+.summary-empty p {
+  margin: 0;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.summary-footer {
+  color: rgba(15, 23, 42, 0.5);
+}
+
+.summary-footer small {
+  font-size: 0.75rem;
+}
+
+@media (min-width: 720px) {
+  .summary-actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/app/components/session-summary/session-summary.component.ts
+++ b/src/app/components/session-summary/session-summary.component.ts
@@ -10,7 +10,8 @@ type Action = { key: 'pdf' | 'xlsx' | 'csv'; label: string; css: string; run: ()
   selector: 'session-summary',
   standalone: true,
   imports: [CommonModule],
-  templateUrl: './session-summary.component.html'
+  templateUrl: './session-summary.component.html',
+  styleUrls: ['./session-summary.component.scss']
 })
 export class SessionSummaryComponent {
   lines = input<Line[]>([]);
@@ -38,19 +39,19 @@ export class SessionSummaryComponent {
   });
 
   metrics = computed<Metric[]>(() => [
-    { label: 'Lines', value: () => String(this.lines().length) },
-    { label: 'Total Qty', value: () => String(this.totalQty()) },
-    { label: 'Total Cost', value: () => `SAR ${this.totalCost().toFixed(2)}` },
-    { label: 'Total Sales (Gross)', value: () => `SAR ${this.totalGross().toFixed(2)}` },
-    { label: 'Total VAT', value: () => `SAR ${this.totalVAT().toFixed(2)}` },
-    { label: 'Net Profit', value: () => `SAR ${this.totalProfit().toFixed(2)}` }
+    { label: 'Lines captured', value: () => String(this.lines().length) },
+    { label: 'Total quantity', value: () => String(this.totalQty()) },
+    { label: 'Cost basis', value: () => `SAR ${this.totalCost().toFixed(2)}` },
+    { label: 'Gross sales', value: () => `SAR ${this.totalGross().toFixed(2)}` },
+    { label: 'VAT collected', value: () => `SAR ${this.totalVAT().toFixed(2)}` },
+    { label: 'Net profit', value: () => `SAR ${this.totalProfit().toFixed(2)}` }
   ]);
 
   actions = computed<Action[]>(() => [
     {
       key: 'pdf',
       label: 'Export PDF',
-      css: 'btn',
+      css: 'btn primary',
       run: () => {
         this.exportSvc.exportSalesTablePDF(this.lines());
       }
@@ -71,7 +72,7 @@ export class SessionSummaryComponent {
     {
       key: 'csv',
       label: 'Export CSV',
-      css: 'ghost',
+      css: 'btn ghost',
       run: () => this.exportSvc.exportCSV(this.lines(), {
         qty: this.totalQty(),
         cost: this.totalCost(),

--- a/src/app/pages/landing-page/landing-page.component.html
+++ b/src/app/pages/landing-page/landing-page.component.html
@@ -1,223 +1,209 @@
-<div class="container">
-  <!-- Hero -->
-  <section class="card hero">
-    <div class="hero-body">
-      <div>
-        <h1 class="title">Welcome to POS & Inventory Hub</h1>
-        <p class="subtitle">
-          Fast tools for cashiers, clear insights for accountants — all in one place.
+<div class="landing page-container">
+  <section class="hero-surface card">
+    <div class="hero-grid">
+      <div class="hero-copy">
+        <span class="section-eyebrow">Retail toolkit</span>
+        <h1 class="hero-title">Modern POS &amp; inventory control in one place</h1>
+        <p class="hero-text">
+          Empower cashiers, accountants, and managers with a unified workspace. Hassib keeps
+          sales, inventory, and quick calculators a tap away on any device.
         </p>
 
-        <div class="cta">
-          <a routerLink="/sales" class="btn primary">Open Sales</a>
-          <a routerLink="/storage" class="btn">Manage Storage</a>
+        <div class="hero-actions">
+          <a routerLink="/sales" class="btn primary">Open sales workspace</a>
+          <a routerLink="/storage" class="btn ghost">Manage inventory</a>
         </div>
+
+        <ul class="hero-highlights">
+          <li>Realtime VAT, margin, and payment helpers</li>
+          <li>Offline-first storage with instant exports</li>
+          <li>Optimised for tablets, phones, and desktop</li>
+        </ul>
       </div>
 
-      <div class="hero-stats">
+      <div class="hero-metrics" aria-label="Inventory at a glance">
         @for (kpi of kpis(); track kpi.label) {
-          <div class="kpi">
-            <div class="kpi-label">{{ kpi.label }}</div>
-            <div class="kpi-value">{{ kpi.value() }}</div>
+          <div class="metric-card">
+            <span class="metric-label">{{ kpi.label }}</span>
+            <span class="metric-value">{{ kpi.value() }}</span>
           </div>
         }
       </div>
     </div>
   </section>
 
-  <!-- Tools Grid -->
-  <main class="grid tools">
-    <!-- VAT Calculator -->
-    <section class="card">
-      <h2 class="card-title">VAT Calculator</h2>
-      <p class="muted">Convert between Net and Gross including/excluding VAT.</p>
+  <section class="toolkit">
+    <header class="toolkit-header">
+      <span class="section-eyebrow">Daily operations</span>
+      <h2 class="section-title">Streamlined helpers for every transaction</h2>
+      <p class="section-subtitle">
+        Reduce manual math, keep pricing accurate, and give your frontline team an intuitive
+        checklist of financial tools.
+      </p>
+    </header>
 
-      <div class="form-row">
-        <label>Mode</label>
-        <div class="segmented">
-          <button type="button"
-                  [class.active]="mode()==='net'"
-                  (click)="setMode('net')">
-            Net → Gross
-          </button>
-          <button type="button"
-                  [class.active]="mode()==='gross'"
-                  (click)="setMode('gross')">
-            Gross → Net
-          </button>
+    <div class="tools-grid">
+      <section class="card tool-card">
+        <h2 class="card-title">VAT calculator</h2>
+        <p class="muted">Convert between net and gross totals, including or excluding VAT.</p>
+
+        <div class="form-row">
+          <label class="strong">Mode</label>
+          <div class="segmented">
+            <button type="button" [class.active]="mode()==='net'" (click)="setMode('net')">
+              Net → Gross
+            </button>
+            <button type="button" [class.active]="mode()==='gross'" (click)="setMode('gross')">
+              Gross → Net
+            </button>
+          </div>
         </div>
-      </div>
 
-      <div class="form-grid">
-        <label>Amount</label>
-        <input type="number" min="0" step="0.01"
-               [value]="amount()"
-               (input)="amount.set(num($event))" />
+        <div class="form-grid">
+          <label>Amount</label>
+          <input type="number" min="0" step="0.01" [value]="amount()" (input)="amount.set(num($event))" />
 
-        <label>VAT %</label>
-        <input type="number" min="0" step="0.1"
-               [value]="vatRate()"
-               (input)="vatRate.set(num($event))" />
-      </div>
-
-      <div class="results">
-        @for (r of vatResults(); track r.label) {
-          <div class="result-item">
-            <div class="result-label">{{ r.label }}</div>
-            <div class="result-value">{{ r.value() }}</div>
-          </div>
-        }
-      </div>
-    </section>
-
-    <!-- Change Helper -->
-    <section class="card">
-      <h2 class="card-title">Change Helper</h2>
-      <p class="muted">Quickly compute the customer’s change and notes breakdown.</p>
-
-      <div class="form-grid">
-        <label>Amount Due</label>
-        <input type="number" min="0" step="0.01"
-               [value]="due()"
-               (input)="due.set(num($event))" />
-
-        <label>Amount Paid</label>
-        <input type="number" min="0" step="0.01"
-               [value]="paid()"
-               (input)="paid.set(num($event))" />
-      </div>
-
-      <div class="results two">
-        <div class="result-item big">
-          <div class="result-label">Change</div>
-          <div class="result-value">SAR {{ change().toFixed(2) }}</div>
+          <label>VAT %</label>
+          <input type="number" min="0" step="0.1" [value]="vatRate()" (input)="vatRate.set(num($event))" />
         </div>
-      </div>
 
-      <div class="breakdown">
-        @for (b of changeBreakdown(); track $index) {
-          <div class="chip">
-            {{ b.count }} × {{ b.denom }}
-          </div>
-        }
-      </div>
-    </section>
-
-    <!-- Margin / Markup -->
-    <section class="card">
-      <h2 class="card-title">Margin & Markup</h2>
-      <p class="muted">Check profitability instantly.</p>
-
-      <div class="form-grid">
-        <label>Cost (SAR)</label>
-        <input type="number" min="0" step="0.01"
-               [value]="cost()"
-               (input)="cost.set(num($event))" />
-
-        <label>Price (SAR)</label>
-        <input type="number" min="0" step="0.01"
-               [value]="price()"
-               (input)="price.set(num($event))" />
-      </div>
-
-      <div class="results three">
-        @for (r of marginResults(); track r.label) {
-          <div class="result-item">
-            <div class="result-label">{{ r.label }}</div>
-            <div class="result-value">{{ r.value() }}</div>
-          </div>
-        }
-      </div>
-    </section>
-
-    <!-- Split Payments -->
-    <section class="card">
-      <h2 class="card-title">Split Payments</h2>
-      <p class="muted">Distribute a total across payment methods.</p>
-
-      <div class="form-grid">
-        <label>Total (SAR)</label>
-        <input type="number" min="0" step="0.01"
-               [value]="totalToSplit()"
-               (input)="totalToSplit.set(num($event))" />
-
-        <label>Ratios (sum any values)</label>
-        <div class="split-grid">
-          @for (f of splitFields; track f.key) {
-            <div class="split-row">
-              <span>{{ f.label }}</span>
-              <input type="number" min="0" step="1"
-                     [value]="split()[f.key]"
-                     (input)="setSplit(f.key, num($event))" />
+        <div class="results three">
+          @for (r of vatResults(); track r.label) {
+            <div class="result-item">
+              <span class="result-label">{{ r.label }}</span>
+              <span class="result-value">{{ r.value() }}</span>
             </div>
           }
         </div>
-      </div>
+      </section>
 
-      <div class="results two">
-        @for (r of splitResults(); track r.label) {
-          <div class="result-item">
-            <div class="result-label">{{ r.label }}</div>
-            <div class="result-value">{{ r.value() }}</div>
+      <section class="card tool-card">
+        <h2 class="card-title">Change helper</h2>
+        <p class="muted">Instantly work out customer change and suggested note breakdowns.</p>
+
+        <div class="form-grid">
+          <label>Amount due</label>
+          <input type="number" min="0" step="0.01" [value]="due()" (input)="due.set(num($event))" />
+
+          <label>Amount paid</label>
+          <input type="number" min="0" step="0.01" [value]="paid()" (input)="paid.set(num($event))" />
+        </div>
+
+        <div class="results two">
+          <div class="result-item big">
+            <span class="result-label">Change</span>
+            <span class="result-value">SAR {{ change().toFixed(2) }}</span>
+          </div>
+        </div>
+
+        <div class="breakdown" aria-live="polite">
+          @for (b of changeBreakdown(); track $index) {
+            <span class="chip">{{ b.count }} × {{ b.denom }}</span>
+          }
+        </div>
+      </section>
+
+      <section class="card tool-card">
+        <h2 class="card-title">Margin &amp; markup</h2>
+        <p class="muted">Quick profit, margin, and markup calculations for product pricing.</p>
+
+        <div class="form-grid">
+          <label>Cost (SAR)</label>
+          <input type="number" min="0" step="0.01" [value]="cost()" (input)="cost.set(num($event))" />
+
+          <label>Price (SAR)</label>
+          <input type="number" min="0" step="0.01" [value]="price()" (input)="price.set(num($event))" />
+        </div>
+
+        <div class="results three">
+          @for (r of marginResults(); track r.label) {
+            <div class="result-item">
+              <span class="result-label">{{ r.label }}</span>
+              <span class="result-value">{{ r.value() }}</span>
+            </div>
+          }
+        </div>
+      </section>
+
+      <section class="card tool-card">
+        <h2 class="card-title">Split payments</h2>
+        <p class="muted">Divide totals between cash, Mada, credit, or on-account terms.</p>
+
+        <div class="form-grid">
+          <label>Total (SAR)</label>
+          <input type="number" min="0" step="0.01" [value]="totalToSplit()" (input)="totalToSplit.set(num($event))" />
+
+          <label>Ratios (sum any values)</label>
+          <div class="split-grid">
+            @for (f of splitFields; track f.key) {
+              <div class="split-row">
+                <span>{{ f.label }}</span>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  [value]="split()[f.key]"
+                  (input)="setSplit(f.key, num($event))"
+                />
+              </div>
+            }
+          </div>
+        </div>
+
+        <div class="results two">
+          @for (r of splitResults(); track r.label) {
+            <div class="result-item">
+              <span class="result-label">{{ r.label }}</span>
+              <span class="result-value">{{ r.value() }}</span>
+            </div>
+          }
+        </div>
+      </section>
+
+      <section class="card tool-card">
+        <h2 class="card-title">Barcode lookup</h2>
+        <p class="muted">Find a stored product instantly and jump into a sale or stock update.</p>
+
+        <div class="form-row">
+          <label>Barcode</label>
+          <input
+            placeholder="Scan or type barcode..."
+            [value]="queryBarcode()"
+            (input)="onBarcodeInput($event)"
+          />
+        </div>
+
+        @if (foundProduct(); as p) {
+          <div class="lookup">
+            <div class="lookup-row"><span>Barcode</span><span class="muted">{{ p.barcode }}</span></div>
+            <div class="lookup-row"><span>Name</span><span class="strong">{{ p.name }}</span></div>
+            <div class="lookup-row"><span>Qty</span><span>{{ p.qty }}</span></div>
+            <div class="lookup-row"><span>Cost</span><span>SAR {{ p.cost.toFixed(2) }}</span></div>
+            <div class="lookup-row"><span>Price</span><span class="strong">SAR {{ p.price.toFixed(2) }}</span></div>
+
+            <div class="hero-actions">
+              <a routerLink="/sales" class="btn primary">Sell this item</a>
+              <a routerLink="/storage" class="btn ghost">Open storage</a>
+            </div>
+          </div>
+        } @else {
+          <div class="empty-state">
+            <p>No product selected. Scan a barcode to see details or add it to storage.</p>
+            <a routerLink="/storage" class="btn ghost">Add a new product</a>
           </div>
         }
-      </div>
-    </section>
+      </section>
+    </div>
+  </section>
 
-    <!-- Barcode Lookup (connected to Inventory) -->
-    <section class="card">
-      <h2 class="card-title">Barcode Lookup</h2>
-      <p class="muted">Search a product stored in inventory by barcode.</p>
-
-      <div class="form-row">
-        <label>Barcode</label>
-        <input placeholder="Scan or type barcode..."
-               [value]="queryBarcode()"
-               (input)="onBarcodeInput($event)" />
-      </div>
-
-      @if (foundProduct(); as p) {
-        <div class="lookup">
-          <div class="lookup-row">
-            <div>Barcode</div><div class="muted">{{ p.barcode }}</div>
-          </div>
-          <div class="lookup-row">
-            <div>Name</div><div class="strong">{{ p.name }}</div>
-          </div>
-          <div class="lookup-row">
-            <div>Qty</div><div>{{ p.qty }}</div>
-          </div>
-          <div class="lookup-row">
-            <div>Cost</div><div>SAR {{ p.cost.toFixed(2) }}</div>
-          </div>
-          <div class="lookup-row">
-            <div>Price</div><div class="strong">SAR {{ p.price.toFixed(2) }}</div>
-          </div>
-
-          <div class="cta">
-            <a routerLink="/sales" class="btn primary">Sell This Item</a>
-            <a routerLink="/storage" class="btn">Open Storage</a>
-          </div>
-        </div>
-      } @else {
-        <div class="empty">
-          <div>No product selected or not found.</div>
-          <div class="mt-2">
-            <a routerLink="/storage" class="btn ghost">Add to Storage</a>
-          </div>
-        </div>
-      }
-    </section>
-  </main>
-
-  <!-- Quick Links -->
-  <section class="card shortcuts">
-    <h2 class="card-title">Quick Actions</h2>
-    <div class="chips">
-      <a routerLink="/sales" class="chip-link">New Sale</a>
-      <a routerLink="/storage" class="chip-link">Import Inventory</a>
-      <a routerLink="/storage" class="chip-link">Manage Products</a>
-      <a routerLink="/sales" class="chip-link">Session Summary</a>
+  <section class="shortcuts card">
+    <h2 class="card-title">Quick actions</h2>
+    <p class="muted">Jump directly into the workspace you need.</p>
+    <div class="chip-list">
+      <a routerLink="/sales" class="chip">New sale</a>
+      <a routerLink="/storage" class="chip">Import inventory</a>
+      <a routerLink="/storage" class="chip">Manage products</a>
+      <a routerLink="/sales" class="chip">Session exports</a>
     </div>
   </section>
 </div>

--- a/src/app/pages/landing-page/landing-page.component.scss
+++ b/src/app/pages/landing-page/landing-page.component.scss
@@ -1,146 +1,277 @@
-/* General layout */
-.container {
+.landing {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3.5rem);
+}
+
+.hero-surface {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.12), rgba(16, 185, 129, 0.1)),
+              radial-gradient(circle at top right, rgba(8, 145, 178, 0.15), transparent 60%),
+              rgba(255, 255, 255, 0.82);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.hero-grid {
   display: grid;
-  gap: 1.25rem;
-  padding: 1rem;
-}
-
-.card {
-  background: var(--card-bg, #fff);
-  border: 1px solid var(--card-border, #e5e7eb);
-  border-radius: 1rem;
-  padding: 1rem;
-  box-shadow: 0 2px 6px rgba(0,0,0,.04);
-}
-
-.card-title {
-  font-weight: 700;
-  font-size: 1.1rem;
-  margin-bottom: .25rem;
-}
-
-.muted { color: #6b7280; }
-.strong { font-weight: 600; }
-
-/* Hero */
-.hero .hero-body {
-  display: grid;
-  gap: 1rem;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
 }
 
 @media (min-width: 900px) {
-  .hero .hero-body {
-    grid-template-columns: 1.1fr .9fr;
+  .hero-grid {
+    grid-template-columns: 1.1fr 0.9fr;
     align-items: center;
   }
 }
 
-.title {
-  font-size: clamp(1.5rem, 2.2vw, 2.25rem);
+.hero-title {
+  font-size: clamp(2rem, 4vw, 3rem);
   font-weight: 800;
-  line-height: 1.1;
-}
-.subtitle { color: #6b7280; margin-top: .35rem; }
-
-.cta {
-  display: flex; gap: .6rem; margin-top: 1rem; flex-wrap: wrap;
+  margin: 0.35rem 0 0.8rem;
+  color: rgba(15, 23, 42, 0.95);
 }
 
-.hero-stats {
+.hero-text {
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  color: rgba(15, 23, 42, 0.68);
+  margin-bottom: clamp(1.25rem, 2.5vw, 1.75rem);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: clamp(1.2rem, 2vw, 1.8rem);
+}
+
+.hero-highlights {
+  margin: 0;
+  padding: 0;
+  list-style: none;
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: .75rem;
+  gap: 0.5rem;
+  color: rgba(15, 23, 42, 0.65);
+  font-size: 0.95rem;
 }
-.kpi {
-  background: #0f172a;
-  color: #fff;
-  border-radius: .75rem;
-  padding: .9rem;
-}
-.kpi-label { font-size: .8rem; opacity: .8; }
-.kpi-value { font-size: 1.2rem; font-weight: 800; margin-top: .15rem; }
 
-/* Tools grid */
-.grid.tools {
-  display: grid;
-  grid-template-columns: repeat(1, minmax(0, 1fr));
-  gap: 1rem;
+.hero-highlights li::before {
+  content: '•';
+  margin-right: 0.4rem;
+  color: rgba(14, 165, 233, 0.9);
 }
-@media (min-width: 1000px) {
-  .grid.tools {
+
+.hero-metrics {
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.metric-card {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 1rem;
+  padding: 1rem 1.1rem;
+  box-shadow: 0 22px 45px -35px rgba(15, 23, 42, 0.55);
+}
+
+.metric-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(15, 23, 42, 0.5);
+}
+
+.metric-value {
+  font-size: clamp(1.3rem, 3vw, 1.8rem);
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.92);
+  margin-top: 0.45rem;
+}
+
+.toolkit {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.toolkit-header {
+  text-align: left;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.tools-grid {
+  display: grid;
+  gap: clamp(1.25rem, 2.5vw, 1.9rem);
+}
+
+@media (min-width: 960px) {
+  .tools-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
-.form-row { display: grid; gap: .5rem; margin-top: .75rem; }
+@media (min-width: 1280px) {
+  .tools-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.tool-card {
+  display: grid;
+  gap: 1rem;
+  position: relative;
+  isolation: isolate;
+}
+
+.form-row,
 .form-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: .75rem;
-  margin-top: .75rem;
+  gap: 0.75rem;
 }
-.form-grid label,
-.form-row label { font-weight: 600; font-size: .9rem; }
 
-input {
-  width: 100%;
-  border: 1px solid #e5e7eb;
-  border-radius: .6rem;
-  padding: .6rem .7rem;
-  font-size: .95rem;
-  outline: none;
+.form-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
-input:focus { border-color: #6366f1; box-shadow: 0 0 0 3px rgba(99,102,241,.12); }
+
+@media (max-width: 640px) {
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+}
 
 .segmented {
-  display: inline-flex; background: #f3f4f6; padding: .25rem; border-radius: .6rem;
+  display: inline-flex;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 0.75rem;
+  padding: 0.25rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  gap: 0.25rem;
 }
+
 .segmented button {
-  border: none; background: transparent; padding: .4rem .8rem; border-radius: .45rem; cursor: pointer; font-weight: 600;
+  border: none;
+  background: transparent;
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.65rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.7);
+  cursor: pointer;
+  transition: var(--transition);
 }
-.segmented button.active { background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.06); }
+
+.segmented button.active {
+  background: rgba(14, 165, 233, 0.15);
+  color: rgba(14, 165, 233, 0.95);
+  box-shadow: inset 0 0 0 1px rgba(14, 165, 233, 0.3);
+}
 
 .results {
-  display: grid; gap: .6rem; grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: .9rem;
+  display: grid;
+  gap: 0.75rem;
 }
-.results.two { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-.results.three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+
+.results.two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.results.three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 640px) {
+  .results.two,
+  .results.three {
+    grid-template-columns: 1fr;
+  }
+}
+
 .result-item {
-  background: #f9fafb; border: 1px solid #eef2f7; border-radius: .6rem; padding: .6rem .7rem;
-}
-.result-item.big .result-value { font-size: 1.2rem; font-weight: 800; }
-.result-label { color: #6b7280; font-size: .8rem; }
-.result-value { font-weight: 700; }
-
-.breakdown { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: .6rem; }
-.chip {
-  padding: .35rem .55rem; border-radius: 999px; border: 1px solid #e5e7eb; background: #fff; font-size: .85rem;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.85rem;
+  padding: 0.75rem 0.9rem;
+  display: grid;
+  gap: 0.25rem;
+  box-shadow: 0 18px 35px -30px rgba(15, 23, 42, 0.4);
 }
 
-/* Split */
-.split-grid { display: grid; gap: .4rem; }
-.split-row { display: grid; grid-template-columns: 1fr 120px; gap: .5rem; align-items: center; }
-
-/* Lookup */
-.lookup { margin-top: .8rem; display: grid; gap: .4rem; }
-.lookup-row { display: grid; grid-template-columns: 130px 1fr; gap: .6rem; align-items: center; }
-.empty { padding: .75rem; border: 1px dashed #e5e7eb; border-radius: .6rem; color: #6b7280; }
-
-/* Buttons, links, chips */
-.btn {
-  display: inline-flex; align-items: center; justify-content: center;
-  gap: .45rem; padding: .55rem .9rem; border-radius: .65rem; border: 1px solid #e5e7eb; background: #fff;
-  font-weight: 700; cursor: pointer; transition: .15s ease;
+.result-item.big .result-value {
+  font-size: 1.3rem;
+  font-weight: 700;
 }
-.btn:hover { transform: translateY(-1px); box-shadow: 0 4px 10px rgba(0,0,0,.05); }
-.btn.primary { background: #4f46e5; border-color: #4f46e5; color: #fff; }
-.btn.ghost { background: transparent; }
 
-
-.shortcuts .chips { display: flex; flex-wrap: wrap; gap: .5rem; margin-top: .5rem; }
-.chip-link {
-  text-decoration: none; color: #111827; background: #f3f4f6; border: 1px solid #e5e7eb;
-  padding: .4rem .7rem; border-radius: 999px; font-weight: 600;
+.result-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: rgba(15, 23, 42, 0.5);
 }
-.chip-link:hover { background: #fff; }
+
+.result-value {
+  font-weight: 700;
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.split-grid {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.split-row {
+  display: grid;
+  grid-template-columns: 1fr 120px;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+@media (max-width: 480px) {
+  .split-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.lookup {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.lookup-row {
+  display: grid;
+  grid-template-columns: 120px 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+@media (max-width: 480px) {
+  .lookup-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.empty-state {
+  margin-top: 1.2rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px dashed rgba(15, 23, 42, 0.15);
+  background: rgba(248, 250, 252, 0.7);
+  color: rgba(15, 23, 42, 0.6);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shortcuts {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shortcuts .chip-list {
+  margin-top: 0.25rem;
+}

--- a/src/app/pages/sales-page/sales-page.component.html
+++ b/src/app/pages/sales-page/sales-page.component.html
@@ -1,32 +1,51 @@
-<div class="container">
- 
+<div class="page-container sales-page">
+  <header class="page-header">
+    <span class="section-eyebrow">Sales</span>
+    <h1 class="section-title">Point of sale workspace</h1>
+    <p class="section-subtitle">
+      Capture line items, generate receipts, and export summaries without leaving the counter.
+      Designed for quick keyboard entry and responsive touch layouts.
+    </p>
+  </header>
 
-  <main class="grid">
-    <section class="card min-w-[40px]">
+  <div class="workspace-grid">
+    <section class="card workspace-main">
       <product-form (submitted)="addReceipt($event)"></product-form>
 
-      <hr class="my-6" />
+      <div class="section-divider"></div>
 
-      <h2 class="text-xl font-bold">Receipts</h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="module-header">
+        <h2>Receipts</h2>
+        <p class="muted">Each submission becomes a printable mini receipt and feeds the summary.</p>
+      </div>
+
+      <div class="receipt-grid">
         @for (receipt of receipts(); track $index) {
           <receipt [lines]="receipt"></receipt>
         }
       </div>
 
-      <hr class="my-6" />
+      <div class="section-divider"></div>
 
+      <div class="module-header">
+        <h2>Product catalogue</h2>
+        <p class="muted">Maintain reusable product templates and pricing presets.</p>
+      </div>
       <product-manager></product-manager>
- 
-      <sale-table [linesInput]="lines()"></sale-table>
+
+      <div class="section-divider"></div>
+
+      <div class="module-header">
+        <h2>Session lines</h2>
+        <p class="muted">Live record of every product sold during the current session.</p>
+      </div>
+      <div class="table-wrapper">
+        <sale-table [linesInput]="lines()"></sale-table>
+      </div>
     </section>
 
-    <aside class="card">
+    <aside class="card workspace-aside">
       <session-summary [lines]="lines()" [receipts]="receipts()"></session-summary>
     </aside>
-  </main>
+  </div>
 </div>
-
-
-
-<!-- // when the barcode is not compleete the product should not appear and form should be empty -->

--- a/src/app/pages/sales-page/sales-page.component.scss
+++ b/src/app/pages/sales-page/sales-page.component.scss
@@ -1,132 +1,101 @@
-/* Enhanced mobile responsiveness styles - Add to your global CSS */
+.sales-page {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 3vw, 2.75rem);
+}
 
-/* Print optimizations */
+.page-header {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.workspace-grid {
+  display: grid;
+  gap: clamp(1.5rem, 2.5vw, 2rem);
+}
+
+@media (min-width: 1100px) {
+  .workspace-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+    align-items: start;
+  }
+}
+
+.workspace-main {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2rem);
+}
+
+.workspace-aside {
+  position: sticky;
+  top: 6.5rem;
+  align-self: start;
+}
+
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.12) 50%, rgba(15, 23, 42, 0) 100%);
+}
+
+.module-header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.module-header h2 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.receipt-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 900px) {
+  .receipt-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.table-wrapper {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+@media (max-width: 960px) {
+  .workspace-aside {
+    position: static;
+  }
+}
+
+@media (max-width: 768px) {
+  .page-header {
+    text-align: left;
+  }
+}
+
 @media print {
-  .print\:hidden { 
-    display: none !important; 
-  }
-  
-  .print\:p-0 { 
-    padding: 0 !important; 
-  }
-  
-  .print\:shadow-none { 
-    box-shadow: none !important; 
-  }
-  
-  .print\:border-none { 
-    border: none !important; 
-  }
-  
-  .print\:mb-2 {
-    margin-bottom: 0.5rem !important;
-  }
-  
-  .print\:bg-transparent {
-    background-color: transparent !important;
-  }
-  
-  .print\:block {
+  .workspace-grid,
+  .workspace-main,
+  .receipt-grid {
     display: block !important;
   }
-  
-  .print\:flex-row {
-    flex-direction: row !important;
+
+  .workspace-aside,
+  .module-header p,
+  .section-divider,
+  .top-nav,
+  .app-footer {
+    display: none !important;
   }
-  
-  /* Ensure good print layout */
-  body {
-    print-color-adjust: exact;
-    -webkit-print-color-adjust: exact;
+
+  .card,
+  .workspace-main {
+    box-shadow: none !important;
+    border: none !important;
+    padding: 0 !important;
   }
-}
-
-/* Mobile table enhancements */
-@media (max-width: 640px) {
-  /* Ensure horizontal scroll works smoothly */
-  .overflow-x-auto {
-    -webkit-overflow-scrolling: touch;
-    scrollbar-width: thin;
-  }
-  
-  /* Improve touch targets on mobile */
-  button {
-    min-height: 44px;
-    min-width: 44px;
-  }
-  
-  /* Better spacing for mobile cards */
-  .mobile-card {
-    margin-bottom: 1rem;
-  }
-}
-
-/* Improved file input styling for all browsers */
-input[type="file"] {
-  width: 100%;
-}
-
-input[type="file"]::-webkit-file-upload-button {
-  margin-right: 1rem;
-  padding: 0.5rem 1rem;
-  border-radius: 0.375rem;
-  border: none;
-  font-size: 0.875rem;
-  font-weight: 600;
-  background-color: #0d9488;
-  color: white;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-input[type="file"]::-webkit-file-upload-button:hover {
-  background-color: #0f766e;
-}
-
-/* Smooth transitions for interactive elements */
-.transition-colors {
-  transition-property: color, background-color, border-color;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-}
-
-/* Focus styles for accessibility */
-.focus\:ring-2:focus {
-  box-shadow: 0 0 0 2px rgba(13, 148, 136, 0.5);
-  outline: none;
-}
-
-.focus\:border-teal-500:focus {
-  border-color: #14b8a6;
-}
-
-/* Truncate text helper */
-.truncate {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-/* Ensure proper spacing in flex layouts */
-.space-y-3 > * + * {
-  margin-top: 0.75rem;
-}
-
-.space-y-4 > * + * {
-  margin-top: 1rem;
-}
-
-.space-y-6 > * + * {
-  margin-top: 1.5rem;
-}
-
-/* Better mobile typography */
-@media (max-width: 640px) {
-  h1 { font-size: 1.5rem; }
-  h2 { font-size: 1.25rem; }
-  h3 { font-size: 1.125rem; }
-  
-  /* Ensure readable text size */
-  .text-xs { font-size: 0.75rem; }
-  .text-sm { font-size: 0.875rem; }
 }

--- a/src/app/pages/storage-page/storage-page.component.html
+++ b/src/app/pages/storage-page/storage-page.component.html
@@ -1,32 +1,50 @@
-<div class="container   ">
+<div class="page-container storage-page">
+  <header class="page-header">
+    <span class="section-eyebrow">Inventory</span>
+    <h1 class="section-title">Storage control centre</h1>
+    <p class="section-subtitle">
+      Keep product data clean, import spreadsheets in seconds, and synchronise pricing with your
+      sales team from any device.
+    </p>
+  </header>
 
   <app-import-products></app-import-products>
 
-
-  <main class="grid ">
-    <section class="card min-w-[40px]">
+  <div class="workspace-grid">
+    <section class="card workspace-main">
+      <div class="module-header">
+        <h2>Add products</h2>
+        <p class="muted">Capture SKU details and update stock levels instantly.</p>
+      </div>
       <product-form
         [showPayment]="false"
         [showPhone]="false"
         [showVAT]="false"
-        [submitLabel]="'Add to Storage'"
+        [submitLabel]="'Add to storage'"
         (submitted)="addProduct($event)"
       ></product-form>
 
-      <hr class="my-6" />
+      <div class="section-divider"></div>
 
-      <h2 class="text-xl font-bold">Stored Products</h2>
+      <div class="module-header">
+        <h2>Stored items</h2>
+        <p class="muted">Overview of products currently held in inventory.</p>
+      </div>
+      <div class="table-wrapper">
+        <sale-table [linesInput]="inventory.products()"></sale-table>
+      </div>
 
-<sale-table [linesInput]="inventory.products()"></sale-table>
+      <div class="section-divider"></div>
 
-      <hr class="my-6" />
- 
+      <div class="module-header">
+        <h2>Quick editor</h2>
+        <p class="muted">Adjust pricing, costs, or remove products in bulk.</p>
+      </div>
       <product-manager></product-manager>
     </section>
 
-    <aside>
-<storage-summary [lines]="inventory.products()"></storage-summary>
-
+    <aside class="card workspace-aside">
+      <storage-summary [lines]="inventory.products()"></storage-summary>
     </aside>
-  </main>
+  </div>
 </div>

--- a/src/app/pages/storage-page/storage-page.scss
+++ b/src/app/pages/storage-page/storage-page.scss
@@ -1,0 +1,61 @@
+.storage-page {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 3vw, 2.75rem);
+}
+
+.page-header {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.workspace-grid {
+  display: grid;
+  gap: clamp(1.5rem, 2.5vw, 2rem);
+}
+
+@media (min-width: 1100px) {
+  .workspace-grid {
+    grid-template-columns: minmax(0, 1fr) minmax(280px, 340px);
+    align-items: start;
+  }
+}
+
+.workspace-main {
+  display: grid;
+  gap: clamp(1.5rem, 2vw, 2rem);
+}
+
+.workspace-aside {
+  position: sticky;
+  top: 6.5rem;
+  align-self: start;
+}
+
+.section-divider {
+  height: 1px;
+  background: linear-gradient(90deg, rgba(15, 23, 42, 0) 0%, rgba(15, 23, 42, 0.12) 50%, rgba(15, 23, 42, 0) 100%);
+}
+
+.module-header {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.module-header h2 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.table-wrapper {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+@media (max-width: 960px) {
+  .workspace-aside {
+    position: static;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -1,18 +1,28 @@
 <!doctype html>
-<html lang="en"   >
+<html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Hassib</title>
+  <title>Hassib POS &amp; Inventory Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Hassib combines lightning-fast POS workflows with modern inventory controls, VAT tools, and exportable reports optimised for retail teams.">
+  <meta name="keywords" content="point of sale, inventory management, VAT calculator, retail software, Hassib">
   <meta name="theme-color" content="#0ea5a4">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Hassib POS &amp; Inventory Hub">
+  <meta property="og:description" content="Modern sales and stock control for teams that need accurate numbers everywhere.">
+  <meta property="og:image" content="/assets/icon-192.svg">
+  <meta property="og:url" content="https://hassib.local/">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Hassib POS &amp; Inventory Hub">
+  <meta name="twitter:description" content="Modern POS and inventory tools with offline-first storage and fast exports.">
   <link rel="icon" type="image/svg+xml" href="assets/icon-192.svg">
   <link rel="manifest" href="manifest.webmanifest">
   <base href="/">
-  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
+  <link rel="canonical" href="https://hassib.local/">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
-<body  >
-   <app-root></app-root>
-  
+<body>
+  <app-root></app-root>
 </body>
 </html>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,83 +1,326 @@
-
-// Include theming for Angular Material with `mat.theme()`.
-// This Sass mixin will define CSS variables that are used for styling Angular Material
-// components according to the Material 3 design spec.
-// Learn more about theming and how to use it for your application's
-// custom components at https://material.angular.dev/guide/theming
 @use '@angular/material' as mat;
 
 html {
   @include mat.theme((
     color: (
-      primary: mat.$azure-palette,
-      tertiary: mat.$blue-palette,
+      primary: mat.$cyan-palette,
+      tertiary: mat.$green-palette,
     ),
     typography: Roboto,
     density: 0,
   ));
 }
 
-body {
-  // Default the application to a light color theme. This can be changed to
-  // `dark` to enable the dark color theme, or to `light dark` to defer to the
-  // user's system settings.
+:root {
   color-scheme: light;
-
-  // Set a default background, font and text colors for the application using
-  // Angular Material's system-level CSS variables. Learn more about these
-  // variables at https://material.angular.dev/guide/system-variables
-  background-color: var(--mat-sys-surface);
-  color: var(--mat-sys-on-surface);
-  font: var(--mat-sys-body-medium);
-
-  // Reset the user agent margin.
-  margin: 0;
+  --bg-muted: #f1f5f9;
+  --bg-strong: #e2e8f0;
+  --surface: rgba(255, 255, 255, 0.92);
+  --surface-elevated: rgba(255, 255, 255, 0.98);
+  --border: rgba(15, 23, 42, 0.08);
+  --text-primary: #0f172a;
+  --text-muted: rgba(15, 23, 42, 0.6);
+  --accent: #0f766e;
+  --accent-strong: #0d9488;
+  --shadow-soft: 0 25px 60px -35px rgba(15, 23, 42, 0.45);
+  --radius-xl: 1.25rem;
+  --radius-lg: 1rem;
+  --transition: all 0.22s ease;
 }
-@import './tailwind-input.css';
 
-/* You can add global styles to this file, and also import other style files */
-:root{--bg:#f7fafc;--card:#ffffff;--muted:#6b7280;--accent:#0ea5a4;--danger:#ef4444;--glass:rgba(255,255,255,0.6)}
-html,body{height:100%}
-body{margin:0;font-family:Inter,Segoe UI,Roboto,Arial,sans-serif;background:linear-gradient(180deg,#f8fafc 0%,#eef2f7 100%);color:#0f172a;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;padding:16px}
-.container{max-width:1100px;margin:0 auto}
-header{display:flex;align-items:center;justify-content:space-between;margin-bottom:14px}
-.brand{display:flex;align-items:center;gap:12px}
-.logo{width:56px;height:56px;background:var(--card);border-radius:8px;display:flex;align-items:center;justify-content:center;box-shadow:0 1px 3px rgba(2,6,23,.08)}
-.logo img{max-width:46px;max-height:46px}
-h1{font-size:18px;margin:0}
-p.lead{margin:4px 0 0;color:var(--muted);font-size:13px}
-.disclaimer{font-size:12px;color:var(--muted);margin-top:8px;background:rgba(15,23,42,.03);padding:10px;border-radius:8px}
-.grid{display:grid;grid-template-columns:1fr 360px;gap:16px;margin-top:12px}
-.card{background:var(--card);border-radius:10px;padding:12px;box-shadow:0 6px 18px rgba(15,23,42,.04)}
-.controls{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px}
-label{font-size:13px;color:var(--muted)}
-input[type="text"],input[type="number"],select{width:100%;padding:8px;border-radius:8px;border:1px solid #e6eef4;background:transparent;font-size:14px}
-.row{display:flex;gap:8px}.row>*{flex:1}
-button.btn{background:var(--accent);color:#fff;border:none;padding:10px 12px;border-radius:8px;cursor:pointer}
-button.ghost{background:transparent;border:1px solid #e2e8f0;padding:8px;border-radius:8px;cursor:pointer}
-table{width:100%;border-collapse:collapse;margin-top:8px}
-th,td{padding:8px 6px;border-bottom:1px solid rgba(2,6,23,.04);font-size:13px;text-align:center}
-th{background:#fbfbfc;font-weight:600;color:#0f172a}
-tfoot td{font-weight:700}
-.summary{display:flex;flex-direction:column;gap:8px;margin-top:8px}
-.metric{display:flex;justify-content:space-between;padding:8px;border-radius:8px;background:linear-gradient(90deg,#fbfdff,#fff)}
-.small{font-size:12px;color:var(--muted)}
-.payment-break{font-size:13px;color:var(--muted)}
-.actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
-.mobile-hide{display:block}
-@media(max-width:900px){.grid{grid-template-columns:1fr}.mobile-hide{display:none}}
-.footer-note{font-size:12px;color:var(--muted);margin-top:10px}
-.prod-manager{margin-top:12px;border-top:1px dashed #eef2f6;padding-top:10px}
-.prod-row{display:flex;gap:8px;margin-top:6px}
-.prod-row input{padding:8px;border-radius:8px;border:1px solid #e6eef4}
-.prod-list{margin-top:10px;display:flex;flex-direction:column;gap:6px}
-.prod-chip{display:flex;justify-content:space-between;align-items:center;padding:8px;border-radius:8px;background:#fbfbff;border:1px solid #eef2f6;font-size:13px}
-.pay-manager{margin-top:10px;border-top:1px dashed #e6eef4;padding-top:10px}
-.pay-list{margin-top:8px;display:flex;flex-direction:column;gap:6px}
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
 
-html, body { height: 100%; }
- 
-html, body {
-  overflow-x: hidden;
-  max-width: 100vw;
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Inter', 'Roboto', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 35%, #f9fafb 100%);
+  color: var(--text-primary);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
+  outline: 2px solid rgba(6, 182, 212, 0.55);
+  outline-offset: 2px;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.page-container {
+  width: min(1200px, 100%);
+  margin-inline: auto;
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: clamp(1.25rem, 2.2vw, 1.9rem);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(14px);
+}
+
+.card-title {
+  font-size: clamp(1.05rem, 1.7vw, 1.3rem);
+  font-weight: 700;
+  margin-bottom: 0.35rem;
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.strong {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.btn,
+button.btn,
+a.btn,
+button.ghost,
+a.ghost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.9rem;
+  border: 1px solid transparent;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.65rem 1.2rem;
+  transition: var(--transition);
+  cursor: pointer;
+}
+
+.btn,
+button.btn,
+a.btn {
+  background: linear-gradient(135deg, rgba(15, 118, 110, 0.92), rgba(8, 145, 178, 0.92));
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 16px 30px -20px rgba(8, 145, 178, 0.7);
+}
+
+.btn:hover,
+button.btn:hover,
+a.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 40px -20px rgba(6, 182, 212, 0.6);
+}
+
+.btn.primary,
+button.primary,
+a.primary {
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.95), rgba(16, 185, 129, 0.95));
+  box-shadow: 0 18px 34px -20px rgba(16, 185, 129, 0.65);
+}
+
+.btn.ghost,
+button.ghost,
+a.ghost {
+  background: rgba(255, 255, 255, 0.65);
+  border-color: rgba(15, 23, 42, 0.08);
+  color: var(--text-primary);
+  box-shadow: 0 12px 24px -22px rgba(15, 23, 42, 0.6);
+}
+
+.btn.ghost:hover,
+button.ghost:hover,
+a.ghost:hover {
+  border-color: rgba(13, 148, 136, 0.45);
+  color: rgba(13, 148, 136, 0.95);
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.9);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: rgba(14, 165, 233, 0.55);
+  box-shadow: 0 0 0 3px rgba(6, 182, 212, 0.15);
+  outline: none;
+}
+
+input[type='file'] {
+  padding: 0.35rem;
+  cursor: pointer;
+}
+
+input[type='file']::file-selector-button {
+  margin-right: 1rem;
+  padding: 0.55rem 1rem;
+  border-radius: 0.65rem;
+  border: none;
+  font-weight: 600;
+  background: linear-gradient(135deg, rgba(14, 165, 233, 0.9), rgba(20, 184, 166, 0.9));
+  color: #fff;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+input[type='file']::file-selector-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px -20px rgba(6, 182, 212, 0.6);
+}
+
+.table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  background: var(--surface-elevated);
+}
+
+.table-scroll {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 640px;
+  font-size: 0.9rem;
+}
+.data-table thead {
+  background: rgba(15, 23, 42, 0.04);
+}
+.data-table th {
+  text-align: left;
+  font-weight: 600;
+  padding: 0.75rem 0.9rem;
+  color: rgba(15, 23, 42, 0.75);
+  letter-spacing: 0.01em;
+}
+.data-table td {
+  padding: 0.65rem 0.9rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.05);
+}
+.data-table tfoot td {
+  font-weight: 600;
+  padding: 0.75rem 0.9rem;
+  background: rgba(14, 116, 144, 0.04);
+}
+
+.payment-break {
+  font-size: 0.85rem;
+  color: rgba(15, 23, 42, 0.65);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(14, 165, 233, 0.12);
+  color: rgba(14, 165, 233, 0.9);
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.85);
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+.section-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: rgba(14, 165, 233, 0.85);
+}
+
+.section-title {
+  font-size: clamp(1.5rem, 2.8vw, 2.4rem);
+  font-weight: 700;
+  margin: 0.2rem 0 0.6rem;
+}
+
+.section-subtitle {
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  color: var(--text-muted);
+  max-width: 36rem;
+}
+
+.shadow-surface {
+  box-shadow: var(--shadow-soft);
+}
+
+@media (max-width: 900px) {
+  .table-wrapper {
+    margin-bottom: 1.25rem;
+  }
+
+  .data-table {
+    min-width: 520px;
+  }
+}
+
+@media (max-width: 600px) {
+  .card {
+    border-radius: 1rem;
+    padding: 1.1rem;
+  }
+
+  .btn,
+  button.btn,
+  a.btn,
+  button.ghost,
+  a.ghost {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- Refresh the root layout with a sticky glassmorphism navigation bar, full-width workspace padding, and a branded footer for the POS experience.
- Redesign the landing, sales, and storage pages with responsive grids, modern cards, and updated tables while removing the redundant live sales snapshot messaging.
- Modernize the session summary component with actionable metrics and themed exports, and enhance global styling plus head metadata for SEO and sharing.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfc0205c0883249c8e0c48507168d7