### PR TITLE
feat: add dynamic marketing landing sales trend

### DIFF
--- a/src/app/pages/marketing-landing/marketing-landing.component.html
+++ b/src/app/pages/marketing-landing/marketing-landing.component.html
@@ -51,12 +51,27 @@
           <p class="mt-2 text-2xl font-semibold text-slate-900">Home Fragrance</p>
         </li>
       </ul>
-      <div class="mt-8 grid grid-cols-5 items-end gap-2 rounded-2xl bg-gradient-to-br from-teal-50 via-white to-slate-50 p-4">
-        <div class="h-28 rounded-full bg-teal-100"></div>
-        <div class="h-36 rounded-full bg-teal-300"></div>
-        <div class="h-20 rounded-full bg-teal-100"></div>
-        <div class="h-40 rounded-full bg-teal-500"></div>
-        <div class="h-32 rounded-full bg-teal-200"></div>
+      <div class="mt-8 rounded-2xl bg-gradient-to-br from-teal-50 via-white to-slate-50 p-4">
+        <div class="relative">
+          <div class="flex h-32 items-end gap-2">
+            @for (point of salesTrend; track point.label) {
+              <div class="flex-1 min-w-[0.75rem]">
+                <span class="sr-only">{{ point.label }} — SAR {{ point.amount | number: '1.0-0' }}</span>
+                <div
+                  class="w-full rounded-t-2xl bg-gradient-to-t from-teal-200 via-teal-400 to-teal-600 transition-all duration-500"
+                  [style.height.%]="trendHeight(point.amount)"
+                  aria-hidden="true"
+                ></div>
+              </div>
+            }
+          </div>
+          <div class="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-teal-100/70" aria-hidden="true"></div>
+        </div>
+        <div class="mt-3 flex justify-between text-[10px] font-medium text-slate-400">
+          @for (point of salesTrend; track point.label) {
+            <span>{{ point.label }}</span>
+          }
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/pages/marketing-landing/marketing-landing.component.ts
+++ b/src/app/pages/marketing-landing/marketing-landing.component.ts
@@ -37,6 +37,18 @@ export class MarketingLandingPage {
     'Works across tablet and desktop with offline support planned'
   ];
 
+  readonly salesTrend: ReadonlyArray<{ label: string; amount: number }> = [
+    { label: '10:00', amount: 8200 },
+    { label: '11:00', amount: 9600 },
+    { label: '12:00', amount: 7800 },
+    { label: '13:00', amount: 11240 },
+    { label: '14:00', amount: 10480 },
+    { label: '15:00', amount: 12650 },
+    { label: '16:00', amount: 11980 }
+  ];
+
+  private readonly peakSalesAmount = this.salesTrend.reduce((max, point) => Math.max(max, point.amount), 0);
+
   schemaMarkup: SafeHtml;
 
   constructor() {
@@ -73,5 +85,14 @@ export class MarketingLandingPage {
     };
 
     this.schemaMarkup = this.sanitizer.bypassSecurityTrustHtml(JSON.stringify(schema));
+  }
+
+  trendHeight(value: number): number {
+    if (!this.peakSalesAmount) {
+      return 0;
+    }
+
+    const percentage = (value / this.peakSalesAmount) * 100;
+    return Math.min(100, Math.max(8, Math.round(percentage)));
   }
 }


### PR DESCRIPTION
## Summary
- add a sales trend dataset and helper to calculate bar heights in the marketing landing page
- replace the static sales bars with a looped gradient chart including baseline and labels for accessibility

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68cfdc707cd48324964e83d17f339c29