### PR TITLE
Refactor navbar links to @for loop

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -1,35 +1,15 @@
 <!-- nav.component.html -->
 <nav class="nav flex gap-4 items-center justify-center bg-white border-b border-gray-200 px-6 py-4 shadow-sm">
-  <a
-    routerLink="/"
-    routerLinkActive="text-green-600 font-semibold"
-    class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
-  >
-    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0h6" />
-    </svg>
-    Main
-  </a>
-
-  <a
-    routerLink="/sales"
-    routerLinkActive="text-green-600 font-semibold"
-    class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
-  >
-    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path d="M4 4h16v4H4zM4 10h16v10H4z" />
-    </svg>
-    Sales
-  </a>
-
-  <a
-    routerLink="/storage"
-    routerLinkActive="text-green-600 font-semibold"
-    class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
-  >
-    <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-      <path d="M3 7l9-4 9 4v13a2 2 0 01-2 2H5a2 2 0 01-2-2z" />
-    </svg>
-    Storage
-  </a>
+  @for (link of navLinks; track link.route) {
+    <a
+      [routerLink]="link.route"
+      routerLinkActive="text-green-600 font-semibold"
+      class="text-gray-600 hover:text-green-600 transition text-sm flex items-center gap-2"
+    >
+      <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+        <path [attr.d]="link.iconPath" />
+      </svg>
+      {{ link.label }}
+    </a>
+  }
 </nav>

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -10,6 +10,24 @@ import { CommonModule } from '@angular/common';
   styleUrls: ['./navbar.component.scss']
 })
 export class NavComponent {
+  readonly navLinks = [
+    {
+      label: 'Main',
+      route: '/',
+      iconPath: 'M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0h6',
+    },
+    {
+      label: 'Sales',
+      route: '/sales',
+      iconPath: 'M4 4h16v4H4zM4 10h16v10H4z',
+    },
+    {
+      label: 'Storage',
+      route: '/storage',
+      iconPath: 'M3 7l9-4 9 4v13a2 2 0 01-2 2H5a2 2 0 01-2-2z',
+    },
+  ] as const;
+
   menuOpen = signal(false);
 
   toggleMenu() {


### PR DESCRIPTION
## Summary
- replace the navbar anchor list with an @for loop fed by a typed navLinks array
- centralize link metadata (label, route, icon path) for easier updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfe7ec33b08324b2f7836a8023f07b