### PR TITLE
feat: integrate supabase storage and sales schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,67 +28,10 @@ To get more help on the Angular CLI use `ng help` or go check out the [Angular C
 
 ## Supabase configuration
 
-The application now persists authentication, inventory and sales data to Supabase. To finish the setup:
+The application persists authentication, inventory and sales data to Supabase. A detailed, step-by-step
+guide covering the required environment variables, database schema, optional indexes, row-level
+security policies and authentication settings is available in [SUPABASE.md](./SUPABASE.md).
 
-1. **Add environment variables**
-   - Copy your project URL and anon key from the Supabase dashboard.
-   - Update both `src/environments/environment.ts` and `src/environments/environment.development.ts`:
-     ```ts
-     export const environment = {
-       production: false, // or true in the production file
-       supabaseUrl: 'https://your-project.supabase.co',
-       supabaseAnonKey: 'public-anon-key'
-     };
-     ```
-   - Restart the dev server after saving the files.
-
-2. **Create the required tables** by running the following SQL in the Supabase SQL editor:
-   ```sql
-   create table if not exists public.inventory_items (
-     id bigserial primary key,
-     barcode text,
-     name text not null,
-     qty numeric not null default 0,
-     price numeric not null default 0,
-     cost numeric not null default 0,
-     gross_total numeric not null default 0,
-     vat_amount numeric not null default 0,
-     profit numeric not null default 0,
-     payment text,
-     phone text,
-     created_at timestamptz default now()
-   );
-
-   create table if not exists public.sales_lines (
-     id bigserial primary key,
-     barcode text,
-     name text not null,
-     qty numeric not null default 0,
-     price numeric not null default 0,
-     cost numeric not null default 0,
-     gross_total numeric not null default 0,
-     vat_amount numeric not null default 0,
-     profit numeric not null default 0,
-     payment text,
-     phone text,
-     created_at timestamptz default now()
-   );
-   ```
-
-3. **Enable row-level security (RLS)** and allow authenticated users to read and write:
-   ```sql
-   alter table public.inventory_items enable row level security;
-   alter table public.sales_lines enable row level security;
-
-   create policy "Inventory access" on public.inventory_items
-     for all using (auth.role() = 'authenticated')
-     with check (auth.role() = 'authenticated');
-
-   create policy "Sales access" on public.sales_lines
-     for all using (auth.role() = 'authenticated')
-     with check (auth.role() = 'authenticated');
-   ```
-
-4. **Configure authentication** in Supabase (email/password is enabled by default). Users created through the sign-up form will receive a confirmation email.
-
-Once these steps are complete, logging in, signing up, importing inventory and recording sales will store data in Supabase. When the credentials are missing the UI will display a warning so you know the integration still needs configuration.
+Once you finish the setup described there, logging in, signing up, importing inventory and recording
+sales will store data in Supabase. When the credentials are missing the UI displays a warning so you
+know the integration still needs configuration.

--- a/SUPABASE.md
+++ b/SUPABASE.md
@@ -1,0 +1,209 @@
+# Supabase Integration Guide
+
+This document explains how the application interacts with Supabase and the steps required to
+configure a project from scratch. Follow the sections in order when setting up a new Supabase
+instance.
+
+## 1. Create a Supabase project
+1. Sign in to [Supabase](https://supabase.com) and create a new project.
+2. Once the project has been provisioned, open **Project Settings → API** and copy the
+   **Project URL** and **anon public key**. These credentials are required by the Angular
+   application.
+
+## 2. Configure environment variables
+Update both `src/environments/environment.ts` and `src/environments/environment.development.ts`
+with the values you copied above:
+
+```ts
+export const environment = {
+  production: false, // set to true in the production file
+  supabaseUrl: 'https://your-project.supabase.co',
+  supabaseAnonKey: 'public-anon-key'
+};
+```
+
+Restart the dev server (`npm start`) after changing these files so that Angular picks up the new
+values.
+
+## 3. Database schema
+The application uses Supabase tables for inventory (storage) and sales data. The statements below
+create the minimum schema and connect the tables together. Run them in the Supabase SQL editor or as
+part of a migration script.
+
+```sql
+create table if not exists public.storage_locations (
+  id bigserial primary key,
+  name text not null,
+  code text unique,
+  address text,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.inventory_items (
+  id bigserial primary key,
+  barcode text,
+  name text not null,
+  qty numeric not null default 0,
+  price numeric not null default 0,
+  cost numeric not null default 0,
+  gross_total numeric not null default 0,
+  vat_amount numeric not null default 0,
+  profit numeric not null default 0,
+  payment text,
+  phone text,
+  location_id bigint references public.storage_locations (id) on delete set null,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now()
+);
+
+create table if not exists public.sales_orders (
+  id bigserial primary key,
+  reference text unique,
+  customer_name text,
+  customer_phone text,
+  payment_method text,
+  subtotal numeric not null default 0,
+  vat_amount numeric not null default 0,
+  total numeric not null default 0,
+  user_id uuid references auth.users (id) on delete set null,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.sales_lines (
+  id bigserial primary key,
+  sale_id bigint references public.sales_orders (id) on delete cascade,
+  inventory_item_id bigint references public.inventory_items (id) on delete set null,
+  barcode text,
+  name text not null,
+  qty numeric not null default 0,
+  price numeric not null default 0,
+  cost numeric not null default 0,
+  gross_total numeric not null default 0,
+  vat_amount numeric not null default 0,
+  profit numeric not null default 0,
+  payment text,
+  phone text,
+  created_at timestamptz default now()
+);
+
+create table if not exists public.inventory_movements (
+  id bigserial primary key,
+  inventory_item_id bigint not null references public.inventory_items (id) on delete cascade,
+  location_id bigint references public.storage_locations (id) on delete set null,
+  change numeric not null,
+  reason text,
+  created_at timestamptz default now()
+);
+```
+
+The Angular services continue to work because `sales_lines` still accepts direct inserts. When you
+start capturing full sales orders in the UI, populate `sale_id` and `inventory_item_id` so each line
+links back to the order header and the item stored in inventory.
+
+### Helpful views and triggers (optional)
+- Track automatic timestamps on updates by adding a trigger:
+  ```sql
+  create or replace function public.set_updated_at()
+  returns trigger as $$
+  begin
+    new.updated_at = timezone('utc', now());
+    return new;
+  end;
+  $$ language plpgsql;
+
+  drop trigger if exists trg_inventory_items_set_updated_at on public.inventory_items;
+  create trigger trg_inventory_items_set_updated_at
+    before update on public.inventory_items
+    for each row execute function public.set_updated_at();
+  ```
+- Create a reporting view that joins orders with their lines and inventory metadata:
+  ```sql
+  create or replace view public.v_sales_detail as
+  select
+    o.id as sale_id,
+    o.reference,
+    o.customer_name,
+    o.payment_method,
+    o.total,
+    o.created_at as sale_created_at,
+    l.id as sales_line_id,
+    l.qty,
+    l.price,
+    l.gross_total,
+    coalesce(i.name, l.name) as item_name,
+    i.location_id
+  from public.sales_orders o
+  join public.sales_lines l on l.sale_id = o.id
+  left join public.inventory_items i on i.id = l.inventory_item_id;
+  ```
+
+### Optional indexes and constraints
+- Add a unique constraint on `inventory_items.barcode` if each barcode should only appear once:
+  ```sql
+  alter table public.inventory_items add constraint inventory_items_barcode_unique unique (barcode);
+  ```
+- Create indexes to speed up common lookups and joins:
+  ```sql
+  create index if not exists idx_inventory_items_barcode on public.inventory_items (barcode);
+  create index if not exists idx_inventory_items_location on public.inventory_items (location_id);
+  create index if not exists idx_sales_lines_sale_id on public.sales_lines (sale_id);
+  create index if not exists idx_sales_lines_created_at on public.sales_lines (created_at desc);
+  ```
+
+## 4. Row Level Security (RLS)
+Enable RLS on the tables so that only authenticated users can access them. The following policies
+provide the minimal permissions required by the application (read and write for authenticated
+users). Add stricter checks if you implement multi-tenant separation.
+
+```sql
+alter table public.inventory_items enable row level security;
+alter table public.sales_lines enable row level security;
+alter table public.storage_locations enable row level security;
+alter table public.sales_orders enable row level security;
+alter table public.inventory_movements enable row level security;
+
+create policy "Inventory read" on public.inventory_items
+  for select using (auth.role() = 'authenticated');
+create policy "Inventory write" on public.inventory_items
+  for insert with check (auth.role() = 'authenticated');
+create policy "Inventory delete" on public.inventory_items
+  for delete using (auth.role() = 'authenticated');
+
+create policy "Sales read" on public.sales_lines
+  for select using (auth.role() = 'authenticated');
+create policy "Sales write" on public.sales_lines
+  for insert with check (auth.role() = 'authenticated');
+create policy "Sales delete" on public.sales_lines
+  for delete using (auth.role() = 'authenticated');
+
+create policy "Storage locations read" on public.storage_locations
+  for select using (auth.role() = 'authenticated');
+create policy "Storage locations write" on public.storage_locations
+  for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+
+create policy "Sales orders access" on public.sales_orders
+  for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+
+create policy "Inventory movements access" on public.inventory_movements
+  for all using (auth.role() = 'authenticated') with check (auth.role() = 'authenticated');
+```
+
+If you require multi-tenant separation (e.g. each user should only see their own data), extend the
+schema with a `user_id uuid references auth.users (id)` column on the tables you need to scope and
+update the policies accordingly (`auth.uid() = user_id`).
+
+## 5. Authentication configuration
+Email/password authentication is enabled by default in Supabase. Make sure SMTP settings are
+configured in **Authentication → Providers** if you want users to receive confirmation or password
+reset emails from your own domain. The Angular application displays configuration errors when the
+Supabase credentials are missing so you can verify everything is wired correctly.
+
+## 6. Local testing tips
+- The services in `src/app/shared/services` read the Supabase settings at application start. When the
+  configuration is missing, the UI surfaces clear error messages, allowing you to finish the setup
+  later without breaking the app.
+- Use the Supabase dashboard or the SQL editor to inspect data inserted by the application during
+  development.
+- When running automated tests (`npm test`), consider mocking the Supabase client if you need to
+  cover behaviours that depend on the backend.
+

--- a/src/app/components/import-products/import-products.component/import-products.component.html
+++ b/src/app/components/import-products/import-products.component/import-products.component.html
@@ -17,6 +17,25 @@
     />
   </div>
 
+  <div class="form-field mt-4">
+    <label class="form-label">Destination location</label>
+    <select class="form-control" [value]="selectedLocationId() ?? ''" (change)="onLocationChange($event)">
+      @if (!locationOptions().length) {
+        <option value="">No locations available</option>
+      } @else {
+        @for (loc of locationOptions(); track loc.id) {
+          <option [value]="loc.id">{{ loc.name }}</option>
+        }
+      }
+    </select>
+    @if (locationLoading()) {
+      <p class="form-hint">Loading storage locations…</p>
+    }
+    @if (locationError()) {
+      <p class="form-hint error">{{ locationError() }}</p>
+    }
+  </div>
+
   <p class="form-hint mt-2">
     Expected columns: <code>barcode</code>, <code>name</code>, <code>qty</code>, <code>price</code>, <code>cost</code>
   </p>

--- a/src/app/components/import-products/import-products.component/import-products.component.ts
+++ b/src/app/components/import-products/import-products.component/import-products.component.ts
@@ -1,8 +1,9 @@
 // import-products.component.ts
-import { Component, inject } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { InventoryService } from '../../../shared/services/inventory-service';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { StorageLocationService } from '../../../shared/services/storage-location.service';
 
 @Component({
   selector: 'app-import-products',
@@ -14,13 +15,35 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 export class ImportProductsComponent {
   private inventory = inject(InventoryService);
   private snackBar = inject(MatSnackBar);
+  private readonly locationService = inject(StorageLocationService);
+
+  readonly locationsSignal = this.locationService.locations();
+  readonly locationLoading = this.locationService.loading();
+  readonly locationError = this.locationService.error();
+
+  readonly locationOptions = computed(() => this.locationsSignal());
+  readonly selectedLocationId = signal<number | null>(null);
+
+  constructor() {
+    effect(() => {
+      const options = this.locationOptions();
+      if (!options.length) {
+        void this.locationService.ensureSeedLocation();
+        return;
+      }
+
+      if (this.selectedLocationId() == null) {
+        this.selectedLocationId.set(options[0]?.id ?? null);
+      }
+    });
+  }
 
   importFile(event: Event): void {
     const input = event.target as HTMLInputElement;
     const file = input.files?.[0];
     if (!file) return;
 
-    this.inventory.importFromExcel(file).then(count => {
+    this.inventory.importFromExcel(file, { locationId: this.selectedLocationId() ?? null }).then(count => {
       this.snackBar.open(`${count} products imported successfully.`, 'Close', {
         duration: 4000,
         panelClass: ['snackbar-success']
@@ -33,5 +56,16 @@ export class ImportProductsComponent {
     });
 
     input.value = '';
+  }
+
+  onLocationChange(event: Event): void {
+    const raw = (event.target as HTMLSelectElement).value;
+    if (raw === '') {
+      this.selectedLocationId.set(null);
+      return;
+    }
+
+    const value = Number(raw);
+    this.selectedLocationId.set(Number.isFinite(value) ? value : null);
   }
 }

--- a/src/app/components/product-form/product-form.component.html
+++ b/src/app/components/product-form/product-form.component.html
@@ -57,6 +57,36 @@
     </div>
 
     <div class="form-grid form-grid--meta">
+      @if (showLocation()) {
+        <div class="form-field">
+          <label class="form-label">Storage location</label>
+          <div class="flex items-center gap-2">
+            <select
+              class="form-control"
+              [value]="locationId() ?? ''"
+              (change)="onLocationChange($event)"
+            >
+              @if (!locationOptions().length) {
+                <option value="">No locations available</option>
+              } @else {
+                @for (loc of locationOptions(); track loc.id) {
+                  <option [value]="loc.id">{{ loc.name }}</option>
+                }
+              }
+            </select>
+            <button type="button" class="btn ghost" (click)="createLocation()">
+              Add
+            </button>
+          </div>
+          @if (locationLoading()) {
+            <p class="helper">Loading locations…</p>
+          }
+          @if (locationError()) {
+            <p class="helper error">{{ locationError() }}</p>
+          }
+        </div>
+      }
+
       @if (showVAT()) {
         <div class="form-field">
           <label class="form-label">VAT (%)</label>

--- a/src/app/components/sale-table/sale-table.component.html
+++ b/src/app/components/sale-table/sale-table.component.html
@@ -3,7 +3,7 @@
   <table class="ui-table" aria-live="polite">
     <thead>
       <tr>
-        @for (col of columns; track col.key) {
+        @for (col of columns(); track col.key) {
           <th scope="col">{{ col.label }}</th>
         }
       </tr>
@@ -12,7 +12,7 @@
     <tbody>
       @for (ln of lines(); track $index; let i = $index) {
         <tr>
-          @for (col of columns; track col.key) {
+          @for (col of columns(); track col.key) {
             <td class="whitespace-nowrap" [ngClass]="col.class">
               {{ col.format ? col.format({ line: ln, index: i }) : '' }}
             </td>
@@ -25,7 +25,7 @@
       @for (footerRow of [0, 1]; track $index; let r = $index) {
         <tr>
           @if (r === 0) {
-            <td colspan="3">Totals</td>
+            <td [attr.colspan]="metaTotalsSpan()">Totals</td>
             <td>{{ totalQty() }}</td>
             <td>SAR {{ totalCost() | number:'1.2-2' }}</td>
             <td>SAR {{ totalGross() | number:'1.2-2' }}</td>
@@ -33,7 +33,7 @@
             <td>SAR {{ totalProfit() | number:'1.2-2' }}</td>
             <td colspan="2"></td>
           } @else {
-            <td colspan="4"></td>
+            <td [attr.colspan]="paymentPrefixSpan()"></td>
             <td colspan="6" class="payment-break">
               <strong>By payment:</strong> {{ paymentBreakdownText() }}
             </td>

--- a/src/app/components/sale-table/sale-table.component.ts
+++ b/src/app/components/sale-table/sale-table.component.ts
@@ -33,6 +33,7 @@ export class SaleTableComponent {
    * Signal input used by Angular's binding system. Do NOT change or remove.
    */
   readonly linesInput = input<Line[]>([]);
+  readonly showLocationColumn = input<boolean>(false);
 
   /**
    * Writable internal signal used by the template for both bound and dynamic updates.
@@ -56,7 +57,7 @@ export class SaleTableComponent {
     });
   }
 
-  columns: Column[] = [
+  private readonly baseColumns: Column[] = [
     { key: 'index', label: '#', format: ({ index }) => String(index + 1) },
     { key: 'barcode', label: 'Barcode', format: ({ line }) => line.barcode },
     { key: 'name', label: 'Product', format: ({ line }) => line.name, class: 'text-left pl-2' },
@@ -68,6 +69,24 @@ export class SaleTableComponent {
     { key: 'payment', label: 'Payment', format: ({ line }) => line.payment },
     { key: 'phone', label: 'Phone', format: ({ line }) => line.phone }
   ];
+
+  columns = computed<Column[]>(() => {
+    if (!this.showLocationColumn()) {
+      return this.baseColumns;
+    }
+
+    const withLocation = [...this.baseColumns];
+    withLocation.splice(3, 0, {
+      key: 'location',
+      label: 'Location',
+      class: 'text-left pl-2',
+      format: ({ line }: ColumnFormatArgs) => line.locationName ?? (line.locationId ? `#${line.locationId}` : '—'),
+    });
+    return withLocation;
+  });
+
+  metaTotalsSpan = computed(() => (this.showLocationColumn() ? 4 : 3));
+  paymentPrefixSpan = computed(() => (this.showLocationColumn() ? 5 : 4));
 
   totalQty = computed(() => this.lines().reduce((sum, line) => sum + line.qty, 0));
   totalCost = computed(() => this.lines().reduce((sum, line) => sum + line.cost * line.qty, 0));

--- a/src/app/pages/storage-page/storage-page.component.html
+++ b/src/app/pages/storage-page/storage-page.component.html
@@ -20,6 +20,7 @@
         [showPayment]="false"
         [showPhone]="false"
         [showVAT]="false"
+        [showLocation]="true"
         [submitLabel]="'Add to storage'"
         (submitted)="addProduct($event)"
       ></product-form>
@@ -31,7 +32,7 @@
         <p class="muted">Overview of products currently held in inventory.</p>
       </div>
       <div class="table-wrapper">
-        <sale-table [linesInput]="inventory.products()"></sale-table>
+        <sale-table [linesInput]="inventory.products()" [showLocationColumn]="true"></sale-table>
       </div>
 
       <div class="section-divider"></div>

--- a/src/app/pages/storage-page/storage-page.component.ts
+++ b/src/app/pages/storage-page/storage-page.component.ts
@@ -29,8 +29,14 @@ import { ImportProductsComponent } from '../../components/import-products/import
 export class StoragePage {
   readonly inventory = inject(InventoryService);
 
-  addProduct = async (productSignal: Signal<{ products: ProductFormValue[] }>) => {
-    const { products } = productSignal();
+  addProduct = async (
+    productSignal: Signal<{
+      products: ProductFormValue[];
+      locationId: number | null;
+      locationName: string | null;
+    }>
+  ) => {
+    const { products, locationId, locationName } = productSignal();
 
     const newLines: Line[] = products.map(p => ({
       id: 0,
@@ -44,6 +50,9 @@ export class StoragePage {
       profit: 0,
       payment: 'Cash',
       phone: '',
+      inventoryItemId: null,
+      locationId: locationId ?? null,
+      locationName: locationName ?? null,
     }));
 
     if (!newLines.length) {
@@ -51,7 +60,10 @@ export class StoragePage {
     }
 
     try {
-      await this.inventory.addProducts(newLines);
+      await this.inventory.addProducts(newLines, {
+        locationId: locationId ?? null,
+        reason: 'Manual addition',
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Failed to add products to Supabase.';
       alert(message);

--- a/src/app/shared/models/line.model.ts
+++ b/src/app/shared/models/line.model.ts
@@ -12,4 +12,15 @@ export interface Line {
   profit: number;
   payment: Payment;
   phone: string;
+  /**
+   * Inventory item identifier when the line is linked to a stored product.
+   * Sales lines may not have an associated inventory record and leave this null.
+   */
+  inventoryItemId?: number | null;
+  /** Storage location identifier if the item is stored in a specific warehouse. */
+  locationId?: number | null;
+  /** Optional friendly storage location name for UI display. */
+  locationName?: string | null;
+  /** Related sales order identifier when the line belongs to an order. */
+  saleId?: number | null;
 }

--- a/src/app/shared/models/storage-location.model.ts
+++ b/src/app/shared/models/storage-location.model.ts
@@ -1,0 +1,7 @@
+export interface StorageLocation {
+  id: number;
+  name: string;
+  code: string | null;
+  address: string | null;
+  created_at?: string;
+}

--- a/src/app/shared/services/inventory-service.ts
+++ b/src/app/shared/services/inventory-service.ts
@@ -16,12 +16,36 @@ type InventoryRow = {
   profit: number;
   payment: string | null;
   phone: string | null;
+  location_id: number | null;
+  storage_locations?: {
+    id: number;
+    name: string | null;
+    code: string | null;
+  } | null;
 };
+
+type MovementInsert = {
+  inventory_item_id: number;
+  location_id: number | null;
+  change: number;
+  reason: string;
+};
+
+interface AddProductsOptions {
+  locationId?: number | null;
+  reason?: string;
+}
+
+interface SaleOrderInfo {
+  id?: number;
+  reference?: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class InventoryService {
   private readonly supabase = inject(SupabaseService);
   private readonly table = 'inventory_items';
+  private readonly movementTable = 'inventory_movements';
 
   private readonly productsSignal = signal<Line[]>([]);
   private readonly loadingSignal = signal<boolean>(false);
@@ -59,7 +83,7 @@ export class InventoryService {
       const { data, error } = await client
         .from(this.table)
         .select(
-          'id, barcode, name, qty, price, cost, gross_total, vat_amount, profit, payment, phone'
+          'id, barcode, name, qty, price, cost, gross_total, vat_amount, profit, payment, phone, location_id, storage_locations ( id, name, code )'
         )
         .order('created_at', { ascending: false });
 
@@ -77,7 +101,7 @@ export class InventoryService {
     }
   }
 
-  async addProducts(newProducts: Line[]): Promise<number> {
+  async addProducts(newProducts: Line[], options: AddProductsOptions = {}): Promise<number> {
     if (!newProducts.length) {
       return 0;
     }
@@ -86,13 +110,15 @@ export class InventoryService {
       throw new Error('Supabase credentials are not configured.');
     }
 
-    const payload = newProducts.map(product => this.mapLineToInsertPayload(product));
+    const payload = newProducts.map(product => this.mapLineToInsertPayload(product, options.locationId));
     const client = this.supabase.ensureClient();
 
     const { data, error } = await client
       .from(this.table)
       .insert(payload)
-      .select('id, barcode, name, qty, price, cost, gross_total, vat_amount, profit, payment, phone, created_at')
+      .select(
+        'id, barcode, name, qty, price, cost, gross_total, vat_amount, profit, payment, phone, location_id, storage_locations ( id, name, code )'
+      )
       .order('created_at', { ascending: false });
 
     if (error) {
@@ -102,14 +128,31 @@ export class InventoryService {
     const inserted = (data ?? []).map(row => this.mapRowToLine(row as InventoryRow));
     if (inserted.length) {
       this.productsSignal.update(prev => [...inserted, ...prev]);
+      try {
+        await this.insertMovements(
+          inserted.map(line => ({
+            inventory_item_id: line.id,
+            location_id: line.locationId ?? options.locationId ?? null,
+            change: Math.abs(line.qty),
+            reason: options.reason ?? 'Manual addition',
+          }))
+        );
+      } catch (movementError) {
+        console.error('Failed to record inventory movements', movementError);
+      }
     }
 
     return inserted.length;
   }
 
-  async removeProduct(id: number): Promise<void> {
+  async removeProduct(id: number, reason = 'Manual removal'): Promise<void> {
     if (!this.supabase.isConfigured()) {
       throw new Error('Supabase credentials are not configured.');
+    }
+
+    const existing = this.productsSignal().find(line => line.id === id);
+    if (!existing) {
+      return;
     }
 
     const client = this.supabase.ensureClient();
@@ -120,18 +163,144 @@ export class InventoryService {
     }
 
     this.productsSignal.update(prev => prev.filter(line => line.id !== id));
+
+    try {
+      if (existing.qty > 0) {
+        await this.insertMovements([
+          {
+            inventory_item_id: id,
+            location_id: existing.locationId ?? null,
+            change: -Math.abs(existing.qty),
+            reason,
+          },
+        ]);
+      }
+    } catch (movementError) {
+      console.error('Failed to record inventory removal movement', movementError);
+    }
   }
 
   getByBarcode(barcode: string): Line | undefined {
     return this.productsSignal().find(p => p.barcode === barcode);
   }
 
-  async importFromExcel(file: File): Promise<number> {
+  async importFromExcel(file: File, options: AddProductsOptions = {}): Promise<number> {
     const lines = await this.parseExcel(file);
     if (!lines.length) {
       return 0;
     }
-    return this.addProducts(lines);
+    return this.addProducts(lines, { ...options, reason: options.reason ?? 'Excel import' });
+  }
+
+  async recordSale(lines: Line[], order?: SaleOrderInfo): Promise<void> {
+    if (!lines.length) {
+      return;
+    }
+
+    if (!this.supabase.isConfigured()) {
+      throw new Error('Supabase credentials are not configured.');
+    }
+
+    const client = this.supabase.ensureClient();
+    const products = this.productsSignal();
+
+    const updates: {
+      id: number;
+      qty: number;
+      gross_total: number;
+      vat_amount: number;
+      profit: number;
+    }[] = [];
+    const movements: MovementInsert[] = [];
+    const updatedProducts = new Map<number, Line>();
+
+    for (const line of lines) {
+      const match = products.find(product => {
+        if (line.inventoryItemId != null) {
+          return product.id === line.inventoryItemId;
+        }
+        return !!line.barcode && product.barcode === line.barcode;
+      });
+
+      if (!match) {
+        continue;
+      }
+
+      const newQty = Math.max(0, match.qty - line.qty);
+      const aggregates = this.calculateAggregates(match, newQty);
+
+      updates.push({
+        id: match.id,
+        qty: newQty,
+        gross_total: aggregates.gross_total,
+        vat_amount: aggregates.vat_amount,
+        profit: aggregates.profit,
+      });
+
+      movements.push({
+        inventory_item_id: match.id,
+        location_id: match.locationId ?? null,
+        change: -Math.abs(line.qty),
+        reason: order?.reference ? `Sale ${order.reference}` : 'Sale',
+      });
+
+      updatedProducts.set(match.id, {
+        ...match,
+        qty: newQty,
+        grossTotal: aggregates.gross_total,
+        vatAmount: aggregates.vat_amount,
+        profit: aggregates.profit,
+      });
+    }
+
+    if (!updates.length) {
+      return;
+    }
+
+    for (const update of updates) {
+      const { error } = await client
+        .from(this.table)
+        .update({
+          qty: update.qty,
+          gross_total: update.gross_total,
+          vat_amount: update.vat_amount,
+          profit: update.profit,
+        })
+        .eq('id', update.id);
+
+      if (error) {
+        throw error;
+      }
+    }
+
+    try {
+      await this.insertMovements(movements);
+    } catch (movementError) {
+      console.error('Failed to record sale movement', movementError);
+    }
+
+    this.productsSignal.update(prev =>
+      prev.map(item => {
+        const updated = updatedProducts.get(item.id);
+        return updated ? { ...item, ...updated } : item;
+      })
+    );
+  }
+
+  private async insertMovements(movements: MovementInsert[]): Promise<void> {
+    if (!movements.length) {
+      return;
+    }
+
+    if (!this.supabase.isConfigured()) {
+      return;
+    }
+
+    const client = this.supabase.ensureClient();
+    const { error } = await client.from(this.movementTable).insert(movements);
+    if (error) {
+      throw error;
+    }
   }
 
   private async parseExcel(file: File): Promise<Line[]> {
@@ -163,7 +332,10 @@ export class InventoryService {
               vatAmount: this.round(price * qty * 0.15),
               profit: 0,
               payment: 'Cash',
-              phone: ''
+              phone: '',
+              inventoryItemId: null,
+              locationId: null,
+              locationName: null,
             };
           });
 
@@ -174,12 +346,14 @@ export class InventoryService {
         }
       };
 
-      reader.onerror = (event) => reject(event);
+      reader.onerror = event => reject(event);
       reader.readAsArrayBuffer(file);
     });
   }
 
   private mapRowToLine(row: InventoryRow): Line {
+    const location = row.storage_locations ?? null;
+
     return {
       id: Number(row.id) || 0,
       barcode: row.barcode ?? '',
@@ -191,11 +365,14 @@ export class InventoryService {
       vatAmount: Number(row.vat_amount) || 0,
       profit: Number(row.profit) || 0,
       payment: (row.payment as Line['payment']) ?? 'Cash',
-      phone: row.phone ?? ''
+      phone: row.phone ?? '',
+      inventoryItemId: Number(row.id) || 0,
+      locationId: row.location_id ?? location?.id ?? null,
+      locationName: location?.name ?? null,
     };
   }
 
-  private mapLineToInsertPayload(line: Line) {
+  private mapLineToInsertPayload(line: Line, fallbackLocationId?: number | null) {
     return {
       barcode: line.barcode || null,
       name: line.name,
@@ -206,7 +383,21 @@ export class InventoryService {
       vat_amount: line.vatAmount,
       profit: line.profit,
       payment: line.payment,
-      phone: line.phone || null
+      phone: line.phone || null,
+      location_id: line.locationId ?? fallbackLocationId ?? null,
+    };
+  }
+
+  private calculateAggregates(product: Line, newQty: number) {
+    const grossTotal = this.round(product.price * newQty);
+    const vatRatio = product.grossTotal > 0 ? product.vatAmount / product.grossTotal : 0;
+    const vatAmount = vatRatio > 0 ? this.round(grossTotal * vatRatio) : this.round(product.price * newQty * 0.15);
+    const profit = this.round(grossTotal - vatAmount - product.cost * newQty);
+
+    return {
+      gross_total: grossTotal,
+      vat_amount: vatAmount,
+      profit,
     };
   }
 

--- a/src/app/shared/services/sales.service.ts
+++ b/src/app/shared/services/sales.service.ts
@@ -1,16 +1,28 @@
 import { Injectable, inject } from '@angular/core';
 
-import { Line } from '../models/line.model';
+import { Line, Payment } from '../models/line.model';
 import { SupabaseService } from './supabase.service';
+
+interface SaleReceiptInput {
+  lines: Line[];
+  payment: Payment;
+  customerPhone: string;
+}
+
+interface RecordedOrder {
+  id: number;
+  reference: string;
+}
 
 @Injectable({ providedIn: 'root' })
 export class SalesService {
   private readonly supabase = inject(SupabaseService);
-  private readonly table = 'sales_lines';
+  private readonly orderTable = 'sales_orders';
+  private readonly lineTable = 'sales_lines';
 
-  async recordLines(lines: Line[]): Promise<void> {
-    if (!lines.length) {
-      return;
+  async recordReceipt(receipt: SaleReceiptInput): Promise<RecordedOrder | null> {
+    if (!receipt.lines.length) {
+      return null;
     }
 
     if (!this.supabase.isConfigured()) {
@@ -18,22 +30,85 @@ export class SalesService {
     }
 
     const client = this.supabase.ensureClient();
-    const payload = lines.map(line => ({
-      barcode: line.barcode || null,
-      name: line.name,
-      qty: line.qty,
-      price: line.price,
-      cost: line.cost,
-      gross_total: line.grossTotal,
-      vat_amount: line.vatAmount,
-      profit: line.profit,
-      payment: line.payment,
-      phone: line.phone || null
-    }));
+    const totals = this.calculateTotals(receipt.lines);
+    const reference = this.generateReference();
+    const { data: sessionData } = await client.auth.getSession();
+    const userId = sessionData.session?.user?.id ?? null;
 
-    const { error } = await client.from(this.table).insert(payload);
-    if (error) {
+    const { data: orderRow, error: orderError } = await client
+      .from(this.orderTable)
+      .insert({
+        reference,
+        customer_name: receipt.customerPhone || 'Walk-in customer',
+        customer_phone: receipt.customerPhone || null,
+        payment_method: receipt.payment,
+        subtotal: totals.subtotal,
+        vat_amount: totals.vat,
+        total: totals.total,
+        user_id: userId,
+      })
+      .select('id, reference')
+      .single();
+
+    if (orderError) {
+      throw orderError;
+    }
+
+    const orderId = orderRow?.id ?? null;
+    const saleReference = orderRow?.reference ?? reference;
+
+    try {
+      const linePayload = receipt.lines.map(line => ({
+        sale_id: orderId,
+        inventory_item_id: line.inventoryItemId ?? null,
+        barcode: line.barcode || null,
+        name: line.name,
+        qty: line.qty,
+        price: line.price,
+        cost: line.cost,
+        gross_total: line.grossTotal,
+        vat_amount: line.vatAmount,
+        profit: line.profit,
+        payment: line.payment,
+        phone: line.phone || null,
+      }));
+
+      const { error: lineError } = await client.from(this.lineTable).insert(linePayload);
+      if (lineError) {
+        throw lineError;
+      }
+    } catch (error) {
+      if (orderId) {
+        await client.from(this.orderTable).delete().eq('id', orderId);
+      }
       throw error;
     }
+
+    return orderId ? { id: orderId, reference: saleReference } : null;
+  }
+
+  private calculateTotals(lines: Line[]) {
+    const total = lines.reduce((sum, line) => sum + line.grossTotal, 0);
+    const vat = lines.reduce((sum, line) => sum + line.vatAmount, 0);
+    const subtotal = total - vat;
+
+    return {
+      subtotal: this.round(subtotal),
+      vat: this.round(vat),
+      total: this.round(total),
+    };
+  }
+
+  private generateReference(): string {
+    const now = new Date();
+    const datePart = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(
+      now.getDate()
+    ).padStart(2, '0')}`;
+    const randomPart = Math.random().toString(36).slice(-4).toUpperCase();
+    return `SO-${datePart}-${randomPart}`;
+  }
+
+  private round(value: number): number {
+    return Math.round((value + Number.EPSILON) * 100) / 100;
   }
 }

--- a/src/app/shared/services/storage-location.service.ts
+++ b/src/app/shared/services/storage-location.service.ts
@@ -1,0 +1,143 @@
+import { Injectable, Signal, inject, signal } from '@angular/core';
+
+import { SupabaseService } from './supabase.service';
+import { StorageLocation } from '../models/storage-location.model';
+
+@Injectable({ providedIn: 'root' })
+export class StorageLocationService {
+  private readonly supabase = inject(SupabaseService);
+  private readonly table = 'storage_locations';
+
+  private readonly locationsSignal = signal<StorageLocation[]>([]);
+  private readonly loadingSignal = signal<boolean>(false);
+  private readonly errorSignal = signal<string | null>(null);
+
+  constructor() {
+    void this.refresh();
+  }
+
+  locations(): Signal<StorageLocation[]> {
+    return this.locationsSignal.asReadonly();
+  }
+
+  loading(): Signal<boolean> {
+    return this.loadingSignal.asReadonly();
+  }
+
+  error(): Signal<string | null> {
+    return this.errorSignal.asReadonly();
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.supabase.isConfigured()) {
+      this.locationsSignal.set([]);
+      const configError = this.supabase.configurationError();
+      this.errorSignal.set(configError ? configError() : 'Supabase configuration missing.');
+      return;
+    }
+
+    this.loadingSignal.set(true);
+    this.errorSignal.set(null);
+
+    try {
+      const client = this.supabase.ensureClient();
+      const { data, error } = await client
+        .from(this.table)
+        .select('id, name, code, address, created_at')
+        .order('name', { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      const mapped = (data ?? []).map(row => this.mapRow(row));
+      this.locationsSignal.set(mapped);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to load storage locations.';
+      this.errorSignal.set(message);
+    } finally {
+      this.loadingSignal.set(false);
+    }
+  }
+
+  async ensureSeedLocation(): Promise<void> {
+    if (!this.supabase.isConfigured()) {
+      return;
+    }
+
+    if (this.locationsSignal().length > 0) {
+      return;
+    }
+
+    const client = this.supabase.ensureClient();
+
+    try {
+      const { data, error } = await client
+        .from(this.table)
+        .select('id, name, code, address, created_at')
+        .order('id', { ascending: true })
+        .limit(1);
+
+      if (error) {
+        throw error;
+      }
+
+      if (data && data.length) {
+        this.locationsSignal.set(data.map(row => this.mapRow(row)));
+        return;
+      }
+
+      const { data: inserted, error: insertError } = await client
+        .from(this.table)
+        .insert({ name: 'Main Warehouse', code: 'MAIN' })
+        .select('id, name, code, address, created_at')
+        .single();
+
+      if (insertError) {
+        throw insertError;
+      }
+
+      if (inserted) {
+        this.locationsSignal.set([this.mapRow(inserted)]);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Unable to create a default storage location.';
+      this.errorSignal.set(message);
+    }
+  }
+
+  async createLocation(payload: { name: string; code?: string; address?: string }): Promise<StorageLocation> {
+    if (!this.supabase.isConfigured()) {
+      throw new Error('Supabase credentials are not configured.');
+    }
+
+    const client = this.supabase.ensureClient();
+    const { data, error } = await client
+      .from(this.table)
+      .insert({
+        name: payload.name,
+        code: payload.code?.trim() || null,
+        address: payload.address?.trim() || null,
+      })
+      .select('id, name, code, address, created_at')
+      .single();
+
+    if (error) {
+      throw error;
+    }
+
+    const mapped = this.mapRow(data);
+    this.locationsSignal.update(prev => [...prev, mapped].sort((a, b) => a.name.localeCompare(b.name)));
+    return mapped;
+  }
+
+  private mapRow(row: any): StorageLocation {
+    return {
+      id: Number(row.id) || 0,
+      name: row.name ?? '',
+      code: row.code ?? null,
+      address: row.address ?? null,
+      created_at: row.created_at ?? undefined,
+    } satisfies StorageLocation;
+  }
+}

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -3,9 +3,10 @@ export const environment = {
   /**
    * Supabase project URL. Set this to the value from your Supabase project's settings panel.
    */
-  supabaseUrl: '',
+  supabaseUrl: 'https://demzdobotjkxqxkoqjrv.supabase.co',
   /**
    * Public anon key for the Supabase project. Never commit service role keys.
    */
-  supabaseAnonKey: '',
+  supabaseAnonKey:
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRlbXpkb2JvdGpreHF4a29xanJ2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg0NTc5NzAsImV4cCI6MjA3NDAzMzk3MH0.NThghGWFp6TBAcLUxLQkgTi7JQE8av2_o8Inrzboadg',
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -3,9 +3,10 @@ export const environment = {
   /**
    * Supabase project URL. Set this to the value from your Supabase project's settings panel.
    */
-  supabaseUrl: '',
+  supabaseUrl: 'https://demzdobotjkxqxkoqjrv.supabase.co',
   /**
    * Public anon key for the Supabase project. Never commit service role keys.
    */
-  supabaseAnonKey: '',
+  supabaseAnonKey:
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRlbXpkb2JvdGpreHF4a29xanJ2Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTg0NTc5NzAsImV4cCI6MjA3NDAzMzk3MH0.NThghGWFp6TBAcLUxLQkgTi7JQE8av2_o8Inrzboadg',
 };


### PR DESCRIPTION
## Summary
- add a Supabase-backed storage location service and surface selectors in the product form and import flow
- extend the inventory service to persist location data, write inventory movement history, and sync stock levels after sales
- create linked sales orders with line items tied to inventory and show storage locations in the storage table UI
- configure both environment files with the provided Supabase project URL and anon key so the client can reach the database

## Testing
- npm run lint
- npm run test *(fails due to existing parse error in session-summary.component.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d03ef9db2c83248b4423851474d946