### PR TITLE
Add Supabase linkage tests for sales and storage services

### DIFF
--- a/src/app/shared/services/sales.service.spec.ts
+++ b/src/app/shared/services/sales.service.spec.ts
@@ -1,0 +1,141 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SalesService } from './sales.service';
+import { SupabaseService } from './supabase.service';
+import { Line } from '../models/line.model';
+
+class SupabaseServiceMock {
+  isConfigured = jest.fn(() => true);
+  ensureClient = jest.fn();
+}
+
+describe('SalesService', () => {
+  let service: SalesService;
+  let supabase: SupabaseServiceMock;
+
+  const orderId = 123;
+  let orderInsertPayload: any;
+  let lineInsertPayload: any;
+  let fromMock: jest.Mock;
+  let orderInsert: jest.Mock;
+  let orderSelect: jest.Mock;
+  let orderSingle: jest.Mock;
+  let lineInsert: jest.Mock;
+
+  beforeEach(() => {
+    orderInsertPayload = undefined;
+    lineInsertPayload = undefined;
+
+    orderSingle = jest.fn().mockResolvedValue({ data: { id: orderId, reference: 'SO-ORDER-REF' }, error: null });
+    orderSelect = jest.fn().mockReturnValue({ single: orderSingle });
+    orderInsert = jest.fn().mockImplementation(payload => {
+      orderInsertPayload = payload;
+      return { select: orderSelect };
+    });
+
+    lineInsert = jest.fn().mockImplementation(payload => {
+      lineInsertPayload = payload;
+      return Promise.resolve({ error: null });
+    });
+
+    const orderDeleteEq = jest.fn().mockResolvedValue({ error: null });
+    const orderDelete = jest.fn().mockReturnValue({ eq: orderDeleteEq });
+
+    fromMock = jest.fn().mockImplementation((table: string) => {
+      if (table === 'sales_orders') {
+        return {
+          insert: orderInsert,
+          delete: orderDelete,
+        };
+      }
+
+      if (table === 'sales_lines') {
+        return {
+          insert: lineInsert,
+        };
+      }
+
+      throw new Error(`Unexpected table access: ${table}`);
+    });
+
+    supabase = new SupabaseServiceMock();
+    supabase.ensureClient.mockReturnValue({
+      auth: {
+        getSession: jest.fn().mockResolvedValue({ data: { session: { user: { id: 'user-1' } } } }),
+      },
+      from: fromMock,
+    });
+
+    TestBed.configureTestingModule({
+      providers: [
+        SalesService,
+        { provide: SupabaseService, useValue: supabase },
+      ],
+    });
+
+    service = TestBed.inject(SalesService);
+  });
+
+  it('records receipts by linking sales orders and lines to Supabase tables', async () => {
+    const lines: Line[] = [
+      {
+        id: 1,
+        barcode: '123456789',
+        name: 'Wireless Scanner',
+        qty: 2,
+        price: 250,
+        cost: 150,
+        grossTotal: 500,
+        vatAmount: 65,
+        profit: 135,
+        payment: 'Cash',
+        phone: '0500123456',
+        inventoryItemId: 77,
+      },
+    ];
+
+    const mathRandomSpy = jest.spyOn(Math, 'random').mockReturnValue(0.123456789);
+
+    const result = await service.recordReceipt({
+      lines,
+      payment: 'Cash',
+      customerPhone: '0500123456',
+    });
+
+    expect(fromMock).toHaveBeenNthCalledWith(1, 'sales_orders');
+    expect(fromMock).toHaveBeenNthCalledWith(2, 'sales_lines');
+
+    expect(orderInsert).toHaveBeenCalledTimes(1);
+    expect(orderInsertPayload).toMatchObject({
+      customer_name: '0500123456',
+      customer_phone: '0500123456',
+      payment_method: 'Cash',
+      subtotal: 435,
+      vat_amount: 65,
+      total: 500,
+    });
+    expect(orderInsertPayload.reference).toMatch(/^SO-\d{8}-[A-Z0-9]{4}$/);
+
+    expect(lineInsert).toHaveBeenCalledTimes(1);
+    expect(Array.isArray(lineInsertPayload)).toBe(true);
+    expect(lineInsertPayload).toHaveLength(1);
+    expect(lineInsertPayload[0]).toMatchObject({
+      sale_id: orderId,
+      inventory_item_id: 77,
+      barcode: '123456789',
+      name: 'Wireless Scanner',
+      qty: 2,
+      price: 250,
+      cost: 150,
+      gross_total: 500,
+      vat_amount: 65,
+      profit: 135,
+      payment: 'Cash',
+      phone: '0500123456',
+    });
+
+    expect(result).toEqual({ id: orderId, reference: 'SO-ORDER-REF' });
+
+    mathRandomSpy.mockRestore();
+  });
+});

--- a/src/app/shared/services/storage-location.service.spec.ts
+++ b/src/app/shared/services/storage-location.service.spec.ts
@@ -1,0 +1,121 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+
+import { StorageLocationService } from './storage-location.service';
+import { SupabaseService } from './supabase.service';
+
+class SupabaseServiceMock {
+  private configured = false;
+  private readonly configErrorSignal = signal<string | null>(null);
+
+  readonly isConfigured = jest.fn(() => this.configured);
+  readonly ensureClient = jest.fn();
+  readonly configurationError = jest.fn(() => this.configErrorSignal.asReadonly());
+
+  setConfigured(value: boolean) {
+    this.configured = value;
+  }
+}
+
+describe('StorageLocationService', () => {
+  let service: StorageLocationService;
+  let supabase: SupabaseServiceMock;
+
+  let fromMock: jest.Mock;
+  let selectMock: jest.Mock;
+  let orderMock: jest.Mock;
+  let insertMock: jest.Mock;
+  let insertSelectMock: jest.Mock;
+  let insertSingleMock: jest.Mock;
+  let recordedInsertPayload: any;
+
+  const storageRows = [
+    { id: 1, name: 'Warehouse A', code: 'MAIN', address: 'Riyadh', created_at: '2024-01-01T00:00:00Z' },
+  ];
+
+  beforeEach(() => {
+    recordedInsertPayload = undefined;
+
+    orderMock = jest.fn().mockResolvedValue({ data: storageRows, error: null });
+    selectMock = jest.fn().mockReturnValue({ order: orderMock });
+
+    insertSingleMock = jest.fn().mockResolvedValue({
+      data: { id: 2, name: 'Back Room', code: 'BACK', address: 'Second Floor', created_at: '2024-01-02T00:00:00Z' },
+      error: null,
+    });
+    insertSelectMock = jest.fn().mockReturnValue({ single: insertSingleMock });
+    insertMock = jest.fn().mockImplementation(payload => {
+      recordedInsertPayload = payload;
+      return { select: insertSelectMock };
+    });
+
+    fromMock = jest.fn().mockImplementation((table: string) => {
+      if (table !== 'storage_locations') {
+        throw new Error(`Unexpected table access: ${table}`);
+      }
+
+      return {
+        select: selectMock,
+        insert: insertMock,
+      };
+    });
+
+    supabase = new SupabaseServiceMock();
+    supabase.ensureClient.mockReturnValue({ from: fromMock });
+
+    TestBed.configureTestingModule({
+      providers: [
+        StorageLocationService,
+        { provide: SupabaseService, useValue: supabase },
+      ],
+    });
+
+    service = TestBed.inject(StorageLocationService);
+  });
+
+  it('requests storage locations from the Supabase storage table', async () => {
+    supabase.setConfigured(true);
+    fromMock.mockClear();
+    selectMock.mockClear();
+    orderMock.mockClear();
+
+    await service.refresh();
+
+    expect(supabase.ensureClient).toHaveBeenCalled();
+    expect(fromMock).toHaveBeenCalledWith('storage_locations');
+
+    const locations = service.locations();
+    expect(locations()).toEqual([
+      { id: 1, name: 'Warehouse A', code: 'MAIN', address: 'Riyadh', created_at: '2024-01-01T00:00:00Z' },
+    ]);
+  });
+
+  it('creates new locations by linking inserts to the storage table', async () => {
+    supabase.setConfigured(true);
+    await service.refresh();
+
+    fromMock.mockClear();
+    insertMock.mockClear();
+    insertSelectMock.mockClear();
+    insertSingleMock.mockClear();
+
+    const result = await service.createLocation({ name: 'Back Room', code: ' BACK ', address: 'Second Floor' });
+
+    expect(fromMock).toHaveBeenCalledWith('storage_locations');
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(recordedInsertPayload).toEqual({ name: 'Back Room', code: 'BACK', address: 'Second Floor' });
+    expect(insertSelectMock).toHaveBeenCalledWith('id, name, code, address, created_at');
+    expect(insertSingleMock).toHaveBeenCalled();
+
+    expect(result).toEqual({
+      id: 2,
+      name: 'Back Room',
+      code: 'BACK',
+      address: 'Second Floor',
+      created_at: '2024-01-02T00:00:00Z',
+    });
+
+    const locations = service.locations();
+    expect(locations().map(location => location.name)).toEqual(['Back Room', 'Warehouse A']);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit coverage for SalesService to ensure receipts use the sales_orders and sales_lines tables
- add StorageLocationService tests to verify Supabase table usage when refreshing and inserting locations

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d12cebeb9c8324931b03dba5c87108