### PR TITLE
Refactor storage UI with shared components

### DIFF
--- a/src/app/components/import-products/import-products.component/import-products.component.html
+++ b/src/app/components/import-products/import-products.component/import-products.component.html
@@ -1,4 +1,4 @@
-<section class="form-card upload-card">
+<ui-card class="upload-card" uiCardVariant="surface" [uiCardInteractive]="false">
   <div class="flex items-start justify-between gap-3 flex-wrap">
     <div>
       <h3 class="text-lg font-semibold text-slate-800">Import products</h3>
@@ -12,14 +12,14 @@
       id="fileInput"
       type="file"
       accept=".xlsx"
-      class="form-control"
+      uiInput
       (change)="importFile($event)"
     />
   </div>
 
   <div class="form-field mt-4">
     <label class="form-label">Destination location</label>
-    <select class="form-control" [value]="selectedLocationId() ?? ''" (change)="onLocationChange($event)">
+    <select uiInput [value]="selectedLocationId() ?? ''" (change)="onLocationChange($event)">
       @if (!locationOptions().length) {
         <option value="">No locations available</option>
       } @else {
@@ -39,4 +39,4 @@
   <p class="form-hint mt-2">
     Expected columns: <code>barcode</code>, <code>name</code>, <code>qty</code>, <code>price</code>, <code>cost</code>
   </p>
-</section>
+</ui-card>

--- a/src/app/components/import-products/import-products.component/import-products.component.scss
+++ b/src/app/components/import-products/import-products.component/import-products.component.scss
@@ -16,3 +16,24 @@
   padding: 0.1rem 0.35rem;
   border-radius: 0.35rem;
 }
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.form-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.form-hint {
+  font-size: 0.78rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.form-hint.error {
+  color: #b91c1c;
+}

--- a/src/app/components/import-products/import-products.component/import-products.component.ts
+++ b/src/app/components/import-products/import-products.component/import-products.component.ts
@@ -4,11 +4,12 @@ import { CommonModule } from '@angular/common';
 import { InventoryService } from '../../../shared/services/inventory-service';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { StorageLocationService } from '../../../shared/services/storage-location.service';
+import { UiCardComponent, UiInputComponent } from '../../../ui';
 
 @Component({
   selector: 'app-import-products',
   standalone: true,
-  imports: [CommonModule, MatSnackBarModule],
+  imports: [CommonModule, MatSnackBarModule, UiCardComponent, UiInputComponent],
   templateUrl: './import-products.component.html',
   styleUrls: ['./import-products.component.scss'],
 })

--- a/src/app/components/product-form/product-form.component.html
+++ b/src/app/components/product-form/product-form.component.html
@@ -9,11 +9,13 @@
   </header>
 
   @for (form of productForms(); track $index) {
-    <div class="form-card">
+    <ui-card class="form-card" uiCardVariant="surface" [uiCardInteractive]="false">
       @if (productForms().length > 1) {
         <button
           type="button"
           class="form-card__remove"
+          uiButton="ghost"
+          uiButtonSize="sm"
           (click)="removeProduct($index)"
           aria-label="Remove product"
         >
@@ -30,7 +32,7 @@
             <label class="form-label">{{ field.label }}</label>
             <input
               [type]="field.type"
-              class="form-control"
+              uiInput
               [attr.placeholder]="field.placeholder"
               [value]="field.getter(form)"
               [step]="field.step"
@@ -40,17 +42,17 @@
           </div>
         }
       </div>
-    </div>
+    </ui-card>
   }
 
-  <button type="button" class="link-button" (click)="addProduct()">
+  <button type="button" class="link-button" uiButton="ghost" uiButtonSize="sm" (click)="addProduct()">
     <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
       <path d="M12 5v14M5 12h14" />
     </svg>
     Add another product
   </button>
 
-  <div class="form-card mt-4">
+  <ui-card class="form-card mt-4" uiCardVariant="surface" [uiCardInteractive]="false">
     <div class="flex items-center gap-3 mb-4">
       <span class="badge">Sale details</span>
       <p class="text-sm text-slate-500">Contextual information for receipts and exports.</p>
@@ -62,7 +64,7 @@
           <label class="form-label">Storage location</label>
           <div class="flex items-center gap-2">
             <select
-              class="form-control"
+              uiInput
               [value]="locationId() ?? ''"
               (change)="onLocationChange($event)"
             >
@@ -74,7 +76,7 @@
                 }
               }
             </select>
-            <button type="button" class="btn ghost" (click)="createLocation()">
+            <button type="button" uiButton="ghost" uiButtonSize="sm" (click)="createLocation()">
               Add
             </button>
           </div>
@@ -93,7 +95,7 @@
           <input
             type="number"
             readonly
-            class="form-control"
+            uiInput
             placeholder="VAT Rate"
             [value]="fixedVATRate()"
           />
@@ -104,7 +106,7 @@
         <div class="form-field">
           <label class="form-label">Payment type</label>
           <select
-            class="form-control"
+            uiInput
             [value]="payment()"
             (change)="onPaymentChange($event)"
           >
@@ -120,7 +122,7 @@
           <label class="form-label">Customer phone</label>
           <input
             type="text"
-            class="form-control"
+            uiInput
             placeholder="Customer phone"
             [value]="phone()"
             (input)="onPhoneInput($event)"
@@ -128,17 +130,17 @@
         </div>
       }
     </div>
-  </div>
+  </ui-card>
 
   <div class="form-actions mt-6">
-    <button type="button" class="btn" (click)="submit()">
+    <button type="button" uiButton="primary" (click)="submit()">
       <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
         <path d="M5 13l4 4L19 7" />
       </svg>
       {{ submitLabel() }}
     </button>
 
-    <button type="button" class="btn ghost" (click)="clear()">
+    <button type="button" uiButton="ghost" (click)="clear()">
       <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
         <path d="M3 6h18M9 6v12M15 6v12" />
       </svg>

--- a/src/app/components/product-form/product-form.component.scss
+++ b/src/app/components/product-form/product-form.component.scss
@@ -1,1 +1,104 @@
- 
+:host {
+  display: block;
+}
+
+.form-section {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form-card {
+  position: relative;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.form-card__remove {
+  position: absolute;
+  top: 0.9rem;
+  right: 0.9rem;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  padding: 0;
+  font-size: 0.85rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1.1rem;
+}
+
+@media (min-width: 520px) {
+  .form-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 880px) {
+  .form-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.form-grid--meta {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: rgba(15, 23, 42, 0.75);
+}
+
+.form-hint {
+  font-size: 0.78rem;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.form-hint.error {
+  color: #b91c1c;
+}
+
+.link-button {
+  align-self: flex-start;
+  gap: 0.4rem;
+  font-weight: 600;
+  color: var(--accent-strong);
+  background: transparent;
+  border-color: transparent;
+  box-shadow: none;
+  padding: 0.3rem 0.4rem;
+}
+
+.link-button:hover {
+  background: rgba(14, 165, 233, 0.12);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.form-actions svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.helper {
+  font-size: 0.8rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+.helper.error {
+  color: #b91c1c;
+}

--- a/src/app/components/product-form/product-form.component.ts
+++ b/src/app/components/product-form/product-form.component.ts
@@ -5,6 +5,7 @@ import { CommonModule } from '@angular/common';
 import { InventoryService } from '../../shared/services/inventory-service';
 import { StorageLocationService } from '../../shared/services/storage-location.service';
 import { StorageLocation } from '../../shared/models/storage-location.model';
+import { UiButtonComponent, UiCardComponent, UiInputComponent } from '../../ui';
 
 
 interface ProductSignals {
@@ -18,8 +19,9 @@ interface ProductSignals {
 @Component({
   selector: 'product-form',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, UiButtonComponent, UiCardComponent, UiInputComponent],
   templateUrl: './product-form.component.html',
+  styleUrls: ['./product-form.component.scss'],
 })
 export class ProductFormComponent {
   private inventory = inject(InventoryService);

--- a/src/app/components/product-manager/product-manager.component.html
+++ b/src/app/components/product-manager/product-manager.component.html
@@ -1,35 +1,59 @@
- <div>
-
-<div class="pm-controls">
-  <button class="ghost" type="button" (click)="refreshInventory()" [disabled]="inventory.loading()">
-    Refresh from Supabase
-  </button>
-</div>
-
-@if (inventory.loading()) {
-  <div class="pm-status">Loading inventory from Supabase…</div>
-}
-@if (!inventory.loading() && inventory.error()) {
-  <div class="pm-status error">{{ inventory.error() }}</div>
-}
-
-@for (line of inventory.products(); track line.id) {
-  <div class="prod-chip">
-    <div style="text-align:left">
-      <strong>{{ line.name }}</strong>
-      <div class="small">
-        Barcode: {{ line.barcode || '—' }} • Price: SAR {{ line.price | number:'1.2-2' }} • Qty: {{ line.qty }}
-      </div>
+<ui-card class="product-manager" uiCardVariant="muted" [uiCardInteractive]="false">
+  <header class="product-manager__header">
+    <div class="product-manager__titles">
+      <span class="product-manager__eyebrow">Inventory tools</span>
+      <h3 class="product-manager__title">Quick editor</h3>
+      <p class="product-manager__subtitle">Adjust pricing, costs, or remove products in bulk.</p>
     </div>
-    <button class="ghost" type="button" (click)="removeProduct(line)" [disabled]="inventory.loading()">
-      Delete
+    <button
+      uiButton="outline"
+      uiButtonSize="sm"
+      type="button"
+      (click)="refreshInventory()"
+      [disabled]="inventory.loading()"
+      aria-label="Refresh inventory from Supabase"
+    >
+      <span class="product-manager__refresh-icon" aria-hidden="true">⟳</span>
+      Refresh inventory
     </button>
+  </header>
+
+  @if (inventory.loading()) {
+    <div class="product-manager__status" role="status">Loading inventory from Supabase…</div>
+  }
+
+  @if (!inventory.loading() && inventory.error()) {
+    <div class="product-manager__status product-manager__status--error" role="alert">{{ inventory.error() }}</div>
+  }
+
+  <div class="product-manager__list" role="list">
+    @for (line of inventory.products(); track line.id) {
+      <article class="product-manager__item" role="listitem">
+        <div class="product-manager__details">
+          <h4 class="product-manager__name">{{ line.name }}</h4>
+          <p class="product-manager__meta">
+            <span>Barcode: {{ line.barcode || '—' }}</span>
+            <span>Price: SAR {{ line.price | number: '1.2-2' }}</span>
+            <span>Qty: {{ line.qty }}</span>
+          </p>
+        </div>
+        <button
+          uiButton="ghost"
+          uiButtonSize="sm"
+          type="button"
+          (click)="removeProduct(line)"
+          [disabled]="inventory.loading()"
+        >
+          Remove
+        </button>
+      </article>
+    }
   </div>
-}
-@if (!inventory.loading() && inventory.products().length === 0) {
-  <div class="small" style="color:var(--muted)">No inventory records found in Supabase.</div>
-}
- 
- 
-</div>
- 
+
+  @if (!inventory.loading() && inventory.products().length === 0) {
+    <div class="product-manager__empty">
+      <h4>No stored products yet</h4>
+      <p>Import a spreadsheet or add items on the left to manage them here.</p>
+    </div>
+  }
+</ui-card>

--- a/src/app/components/product-manager/product-manager.component.scss
+++ b/src/app/components/product-manager/product-manager.component.scss
@@ -1,88 +1,131 @@
- 
-.pm-controls {
+:host {
+  display: block;
+}
+
+.product-manager {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.product-manager__header {
   display: flex;
-  justify-content: flex-end;
-  margin-bottom: 0.75rem;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.pm-status {
-  margin-bottom: 0.75rem;
-  font-size: 0.875rem;
-  color: var(--muted);
+@media (min-width: 640px) {
+  .product-manager__header {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
 }
 
-.pm-status.error {
+.product-manager__titles {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.product-manager__eyebrow {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.48);
+}
+
+.product-manager__title {
+  font-size: clamp(1.15rem, 1.8vw, 1.4rem);
+  font-weight: 700;
+  margin: 0;
+  color: var(--text-primary);
+}
+
+.product-manager__subtitle {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.product-manager__status {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(14, 165, 233, 0.08);
+  color: var(--accent-strong);
+  font-size: 0.9rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.product-manager__status--error {
+  background: rgba(248, 113, 113, 0.12);
   color: #b91c1c;
 }
 
-.prod-chip {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  border-radius: 9999px;
-  background: rgba(255, 255, 255, 0.9);
-  margin-bottom: 0.5rem;
-}
-
-.prod-chip .small {
-  font-size: 0.8rem;
-  color: var(--muted);
-}
-
-button.ghost[disabled] {
-  opacity: 0.5;
-  cursor: not-allowed;
- 
-.product-manager {
+.product-manager__list {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.85rem;
 }
 
 .product-manager__item {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
-  padding: 0.85rem 1rem;
-  border-radius: var(--radius-md);
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-lg);
   border: 1px solid rgba(15, 23, 42, 0.08);
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 12px 28px -24px rgba(15, 23, 42, 0.4);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 20px 40px -34px rgba(15, 23, 42, 0.35);
 }
 
 .product-manager__details {
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
+  display: grid;
+  gap: 0.35rem;
 }
 
 .product-manager__name {
+  margin: 0;
+  font-size: 1rem;
   font-weight: 600;
   color: var(--text-primary);
 }
 
 .product-manager__meta {
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
   font-size: 0.85rem;
-  color: var(--text-muted);
+  color: rgba(15, 23, 42, 0.6);
 }
 
 .product-manager__empty {
-  margin: 0.5rem 0 0;
+  border-radius: var(--radius-lg);
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  background: rgba(248, 250, 252, 0.75);
+  padding: 1.25rem 1.5rem;
+  display: grid;
+  gap: 0.35rem;
+  text-align: center;
+}
+
+.product-manager__empty h4 {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.product-manager__empty p {
+  margin: 0;
   font-size: 0.9rem;
   color: var(--text-muted);
 }
 
-@media (max-width: 600px) {
-  .product-manager__item {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .product-manager__details {
-    align-items: flex-start;
-  }
- 
+.product-manager__refresh-icon {
+  font-size: 0.85rem;
 }
+*** End of File

--- a/src/app/components/product-manager/product-manager.component.ts
+++ b/src/app/components/product-manager/product-manager.component.ts
@@ -3,12 +3,14 @@ import { CommonModule } from '@angular/common';
 
 import { InventoryService } from '../../shared/services/inventory-service';
 import { Line } from '../../shared/models/line.model';
+import { UiButtonComponent, UiCardComponent } from '../../ui';
 
 @Component({
   selector: 'product-manager',
   standalone: true,
-  imports: [CommonModule],
-  templateUrl: './product-manager.component.html'
+  imports: [CommonModule, UiButtonComponent, UiCardComponent],
+  templateUrl: './product-manager.component.html',
+  styleUrls: ['./product-manager.component.scss']
 })
 export class ProductManagerComponent {
   readonly inventory = inject(InventoryService);

--- a/src/app/components/receipt/receipt.component.html
+++ b/src/app/components/receipt/receipt.component.html
@@ -1,10 +1,10 @@
-<div class="card receipt-card print:p-0 print:shadow-none print:border-none text-sm">
+<ui-card class="receipt-card print:p-0 print:shadow-none print:border-none text-sm" uiCardVariant="surface" [uiCardInteractive]="false">
   <div class="receipt-card__header">
     <div>
       <h2>Receipt</h2>
       <p class="muted text-xs">Lightweight summary ready for printing or export.</p>
     </div>
-    <button class="btn ghost btn--small print:hidden" (click)="print()">
+    <button uiButton="ghost" uiButtonSize="sm" class="print:hidden" (click)="print()">
       <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor">
         <path d="M6 9V4h12v5" />
         <path d="M6 13h12v7H6z" />
@@ -55,4 +55,4 @@
     <span class="muted text-xs uppercase tracking-widest">VAT included</span>
     <span class="receipt-total">Total: SAR {{ total.toFixed(2) }}</span>
   </div>
-</div>
+</ui-card>

--- a/src/app/components/receipt/receipt.component.ts
+++ b/src/app/components/receipt/receipt.component.ts
@@ -1,12 +1,13 @@
 import { Component, inject, input } from '@angular/core';
 import { CommonModule, DatePipe, CurrencyPipe } from '@angular/common';
 import { Line } from '../../shared/models/line.model';
-import { toQRCodeBase64 } from '../../shared/utils/qrcode-generator.util';  
+import { toQRCodeBase64 } from '../../shared/utils/qrcode-generator.util';
+import { UiButtonComponent, UiCardComponent } from '../../ui';
 
 @Component({
   selector: 'receipt',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, UiButtonComponent, UiCardComponent],
   templateUrl: './receipt.component.html',
   providers: [DatePipe, CurrencyPipe]
 })

--- a/src/app/components/session-summary/session-summary.component.html
+++ b/src/app/components/session-summary/session-summary.component.html
@@ -1,4 +1,4 @@
-<section class="summary-card">
+<ui-card class="summary-card" uiCardVariant="muted" [uiCardInteractive]="false">
   <header class="summary-header">
     <h2>Session overview</h2>
     <p class="muted">Track totals as you register each item. Export options appear below.</p>
@@ -23,7 +23,7 @@
 
     <div class="summary-actions">
       @for (a of actions(); track a.key) {
-        <button class="{{ a.css }}" (click)="a.run()">{{ a.label }}</button>
+        <button type="button" [uiButton]="a.variant" uiButtonSize="sm" (click)="a.run()">{{ a.label }}</button>
       }
     </div>
   } @else {
@@ -35,4 +35,4 @@
   <footer class="summary-footer">
     <small>Tip: exports stay on your device until you choose to share them.</small>
   </footer>
-</section>
+</ui-card>

--- a/src/app/components/session-summary/session-summary.component.ts
+++ b/src/app/components/session-summary/session-summary.component.ts
@@ -2,14 +2,15 @@ import { Component, input, computed, viewChild, ElementRef, inject } from '@angu
 import { CommonModule } from '@angular/common';
 import { Line } from '../../shared/models/line.model';
 import { ExportService } from '../../shared/services/export.service';
+import { UiButtonComponent, UiCardComponent, UiButtonVariant } from '../../ui';
 
 type Metric = { label: string; value: () => string };
-type Action = { key: 'pdf' | 'xlsx' | 'csv'; label: string; css: string; run: () => void };
+type Action = { key: 'pdf' | 'xlsx' | 'csv'; label: string; variant: UiButtonVariant; run: () => void };
 
 @Component({
   selector: 'session-summary',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, UiButtonComponent, UiCardComponent],
   templateUrl: './session-summary.component.html',
   styleUrls: ['./session-summary.component.scss']
 })
@@ -51,7 +52,7 @@ export class SessionSummaryComponent {
     {
       key: 'pdf',
       label: 'Export PDF',
-      css: 'btn primary',
+      variant: 'primary',
       run: () => {
         this.exportSvc.exportSalesTablePDF(this.lines());
       }
@@ -60,7 +61,7 @@ export class SessionSummaryComponent {
     {
       key: 'xlsx',
       label: 'Export Excel',
-      css: 'btn',
+      variant: 'secondary',
       run: () => this.exportSvc.exportXLSX(this.lines(), {
         qty: this.totalQty(),
         cost: this.totalCost(),
@@ -72,7 +73,7 @@ export class SessionSummaryComponent {
     {
       key: 'csv',
       label: 'Export CSV',
-      css: 'btn ghost',
+      variant: 'ghost',
       run: () => this.exportSvc.exportCSV(this.lines(), {
         qty: this.totalQty(),
         cost: this.totalCost(),

--- a/src/app/components/storage-summary/storage-summary.component.html
+++ b/src/app/components/storage-summary/storage-summary.component.html
@@ -1,7 +1,24 @@
-<section class="storage-summary" #reportRoot>
+<ui-card
+  class="storage-summary"
+  uiCardVariant="gradient"
+  uiCardPadding="lg"
+  [uiCardInteractive]="false"
+  #reportRoot
+>
   <header class="storage-summary__header">
-    <h2>Storage summary</h2>
-    <p class="muted">Quick overview of key inventory figures for the current session.</p>
+    <div class="storage-summary__titles">
+      <span class="storage-summary__eyebrow">Snapshot</span>
+      <h2 class="storage-summary__title">Storage summary</h2>
+      <p class="storage-summary__subtitle">Quick overview of key inventory figures for the current session.</p>
+    </div>
+
+    <div class="storage-summary__actions">
+      @for (action of actions(); track action.key) {
+        <button type="button" [uiButton]="action.variant" uiButtonSize="sm" (click)="action.run()">
+          {{ action.label }}
+        </button>
+      }
+    </div>
   </header>
 
   <div class="storage-summary__metrics">
@@ -9,15 +26,10 @@
       <div class="storage-summary__metric">
         <span class="storage-summary__label">{{ metric.label }}</span>
         <span class="storage-summary__value">{{ metric.value() }}</span>
+        @if (metric.hint) {
+          <span class="storage-summary__hint">{{ metric.hint }}</span>
+        }
       </div>
     }
   </div>
-
-  <div class="storage-summary__actions">
-    @for (action of actions(); track action.key) {
-      <button type="button" class="btn ghost btn--small" (click)="action.run()">
-        {{ action.label }}
-      </button>
-    }
-  </div>
-</section>
+</ui-card>

--- a/src/app/components/storage-summary/storage-summary.component.scss
+++ b/src/app/components/storage-summary/storage-summary.component.scss
@@ -1,46 +1,52 @@
 :host {
-  box-sizing: border-box;
+  display: block;
   width: 100%;
 }
 
 .storage-summary {
   display: grid;
+  gap: 2rem;
+  color: var(--text-primary);
+}
+
+.storage-summary__header {
+  display: flex;
+  flex-direction: column;
   gap: 1.25rem;
 }
 
-.storage-summary__header h2 {
-  margin: 0;
-  font-size: 1.3rem;
-  font-weight: 600;
+@media (min-width: 720px) {
+  .storage-summary__header {
+    flex-direction: row;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 2rem;
+  }
 }
 
-.storage-summary__metrics {
+.storage-summary__titles {
   display: grid;
-  gap: 0.9rem;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.4rem;
 }
 
-.storage-summary__metric {
-  padding: 0.85rem 1rem;
-  border-radius: var(--radius-md);
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  background: var(--surface-muted);
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-}
-
-.storage-summary__label {
-  font-size: 0.78rem;
-  letter-spacing: 0.16em;
+.storage-summary__eyebrow {
+  font-size: 0.72rem;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
-  color: rgba(15, 23, 42, 0.55);
+  font-weight: 700;
+  color: rgba(14, 165, 233, 0.85);
 }
 
-.storage-summary__value {
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: var(--text-primary);
+.storage-summary__title {
+  margin: 0;
+  font-size: clamp(1.35rem, 2vw, 1.7rem);
+  font-weight: 700;
+}
+
+.storage-summary__subtitle {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(15, 23, 42, 0.7);
 }
 
 .storage-summary__actions {
@@ -49,9 +55,45 @@
   gap: 0.75rem;
 }
 
-@media (max-width: 600px) {
+.storage-summary__metrics {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.storage-summary__metric {
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-lg);
+  background: rgba(255, 255, 255, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.38);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 28px 46px -38px rgba(14, 165, 233, 0.35);
+  display: grid;
+  gap: 0.35rem;
+}
+
+.storage-summary__label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.storage-summary__value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.storage-summary__hint {
+  font-size: 0.82rem;
+  color: rgba(15, 23, 42, 0.6);
+}
+
+@media (max-width: 640px) {
   .storage-summary__actions {
+    width: 100%;
     flex-direction: column;
-    align-items: stretch;
   }
 }

--- a/src/app/components/storage-summary/storage-summary.component.ts
+++ b/src/app/components/storage-summary/storage-summary.component.ts
@@ -2,15 +2,17 @@ import { Component, computed, input, viewChild, ElementRef, inject } from '@angu
 import { CommonModule } from '@angular/common';
 import { Line } from '../../shared/models/line.model';
 import { ExportService } from '../../shared/services/export.service';
+import { UiButtonComponent, UiCardComponent, UiButtonVariant } from '../../ui';
 
-type Metric = { label: string; value: () => string };
-type Action = { key: 'pdf' | 'xlsx'; label: string; css: string; run: () => void };
+type Metric = { label: string; value: () => string; hint?: string };
+type Action = { key: 'pdf' | 'xlsx'; label: string; variant: UiButtonVariant; run: () => void };
 
 @Component({
   selector: 'storage-summary',
   standalone: true,
-  imports: [CommonModule],
-  templateUrl: './storage-summary.component.html'
+  imports: [CommonModule, UiButtonComponent, UiCardComponent],
+  templateUrl: './storage-summary.component.html',
+  styleUrls: ['./storage-summary.component.scss']
 })
 export class StorageSummaryComponent {
   lines = input<Line[]>([]);
@@ -20,17 +22,17 @@ export class StorageSummaryComponent {
   totalGross = computed(() => this.lines().reduce((sum, line) => sum + line.grossTotal, 0));
 
   metrics = computed<Metric[]>(() => [
-    { label: 'Stored Items', value: () => String(this.lines().length) },
-    { label: 'Total Quantity', value: () => String(this.totalQty()) },
-    { label: 'Total Cost', value: () => `SAR ${this.totalCost().toFixed(2)}` },
-    { label: 'Total Value', value: () => `SAR ${this.totalGross().toFixed(2)}` }
+    { label: 'Stored items', value: () => String(this.lines().length), hint: 'Unique SKUs available today' },
+    { label: 'Total quantity', value: () => String(this.totalQty()), hint: 'Across all storage locations' },
+    { label: 'Inventory cost', value: () => `SAR ${this.totalCost().toFixed(2)}`, hint: 'Current cost basis' },
+    { label: 'Stock value', value: () => `SAR ${this.totalGross().toFixed(2)}`, hint: 'Estimated retail price' }
   ]);
 
   actions = computed<Action[]>(() => [
     {
       key: 'pdf',
       label: 'Export PDF',
-      css: 'btn',
+      variant: 'primary',
       run: () => {
         this.exportSvc.exportSalesTablePDF(this.lines());
       }
@@ -38,7 +40,7 @@ export class StorageSummaryComponent {
     {
       key: 'xlsx',
       label: 'Export Excel',
-      css: 'btn',
+      variant: 'outline',
       run: () => {
         this.exportSvc.exportXLSX(this.lines(), {
           qty: this.totalQty(),
@@ -51,7 +53,7 @@ export class StorageSummaryComponent {
     }
   ]);
 
-  reportRoot = viewChild<ElementRef<HTMLDivElement>>('reportRoot');
+  reportRoot = viewChild<ElementRef<HTMLElement>>('reportRoot');
 
   private readonly exportSvc = inject(ExportService);
 }

--- a/src/app/pages/sales-page/sales-page.component.html
+++ b/src/app/pages/sales-page/sales-page.component.html
@@ -9,7 +9,7 @@
   </header>
 
   <div class="workspace-grid">
-    <section class="card workspace-main">
+    <ui-card class="workspace-main" uiCardVariant="surface" [uiCardInteractive]="false">
       <product-form (submitted)="addReceipt($event)"></product-form>
 
       <div class="section-divider"></div>
@@ -42,10 +42,8 @@
       <div class="table-wrapper">
         <sale-table [linesInput]="lines()"></sale-table>
       </div>
-    </section>
+    </ui-card>
 
-    <aside class="card workspace-aside">
-      <session-summary [lines]="lines()" [receipts]="receipts()"></session-summary>
-    </aside>
+    <session-summary class="workspace-aside" [lines]="lines()" [receipts]="receipts()"></session-summary>
   </div>
 </div>

--- a/src/app/pages/sales-page/sales-page.component.scss
+++ b/src/app/pages/sales-page/sales-page.component.scss
@@ -92,7 +92,6 @@
     display: none !important;
   }
 
-  .card,
   .workspace-main {
     box-shadow: none !important;
     border: none !important;

--- a/src/app/pages/sales-page/sales-page.component.ts
+++ b/src/app/pages/sales-page/sales-page.component.ts
@@ -6,6 +6,7 @@ import { ProductManagerComponent } from '../../components/product-manager/produc
 import { SaleTableComponent } from '../../components/sale-table/sale-table.component';
 import { SessionSummaryComponent } from '../../components/session-summary/session-summary.component';
 import { ReceiptComponent } from '../../components/receipt/receipt.component';
+import { UiCardComponent } from '../../ui';
 
 import { Line, Payment } from '../../shared/models/line.model';
 import { ProductFormValue } from '../../shared/models/product.model';
@@ -21,7 +22,8 @@ import { SalesService } from "../../shared/services/sales.service";
     ProductManagerComponent,
     SaleTableComponent,
     SessionSummaryComponent,
-    ReceiptComponent
+    ReceiptComponent,
+    UiCardComponent
   ],
   templateUrl: './sales-page.component.html',
   styleUrls: ['./sales-page.component.scss']

--- a/src/app/pages/storage-page/storage-page.component.html
+++ b/src/app/pages/storage-page/storage-page.component.html
@@ -11,7 +11,7 @@
   <app-import-products></app-import-products>
 
   <div class="workspace-grid">
-    <section class="card workspace-main">
+    <ui-card class="workspace-main" uiCardVariant="surface" [uiCardInteractive]="false">
       <div class="module-header">
         <h2>Add products</h2>
         <p class="muted">Capture SKU details and update stock levels instantly.</p>
@@ -37,15 +37,9 @@
 
       <div class="section-divider"></div>
 
-      <div class="module-header">
-        <h2>Quick editor</h2>
-        <p class="muted">Adjust pricing, costs, or remove products in bulk.</p>
-      </div>
       <product-manager></product-manager>
-    </section>
+    </ui-card>
 
-    <aside class="card workspace-aside">
-      <storage-summary [lines]="inventory.products()"></storage-summary>
-    </aside>
+    <storage-summary class="workspace-aside" [lines]="inventory.products()"></storage-summary>
   </div>
 </div>

--- a/src/app/pages/storage-page/storage-page.component.ts
+++ b/src/app/pages/storage-page/storage-page.component.ts
@@ -11,6 +11,7 @@ import { StorageSummaryComponent } from '../../components/storage-summary/storag
 import { ProductFormValue } from '../../shared/models/product.model';
 import { Line } from '../../shared/models/line.model';
 import { ImportProductsComponent } from '../../components/import-products/import-products.component/import-products.component';
+import { UiCardComponent } from '../../ui';
 
 @Component({
   selector: 'app-storage-page',
@@ -21,7 +22,8 @@ import { ImportProductsComponent } from '../../components/import-products/import
     ProductManagerComponent,
     SaleTableComponent,
     StorageSummaryComponent,
-    ImportProductsComponent 
+    ImportProductsComponent,
+    UiCardComponent
   ],
   templateUrl: './storage-page.component.html',
   styleUrls: ['./storage-page.scss']

--- a/src/app/ui/index.ts
+++ b/src/app/ui/index.ts
@@ -1,0 +1,3 @@
+export * from './ui-button/ui-button.component';
+export * from './ui-card/ui-card.component';
+export * from './ui-input/ui-input.component';

--- a/src/app/ui/ui-button/ui-button.component.scss
+++ b/src/app/ui/ui-button/ui-button.component.scss
@@ -1,0 +1,111 @@
+:host {
+  --ui-button-bg: linear-gradient(135deg, rgba(14, 165, 233, 0.95), rgba(16, 185, 129, 0.95));
+  --ui-button-color: #fff;
+  --ui-button-border: transparent;
+  --ui-button-shadow: 0 16px 30px -20px rgba(14, 165, 233, 0.6);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--ui-button-border);
+  padding: 0.65rem 1.2rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.1;
+  cursor: pointer;
+  background: var(--ui-button-bg);
+  color: var(--ui-button-color);
+  box-shadow: var(--ui-button-shadow);
+  transition: var(--transition);
+  text-decoration: none;
+}
+
+:host(.ui-button--sm) {
+  padding: 0.45rem 0.85rem;
+  font-size: 0.82rem;
+}
+
+:host(.ui-button--lg) {
+  padding: 0.85rem 1.45rem;
+  font-size: 1rem;
+}
+
+:host(.ui-button--ghost),
+:host(.ui-button--outline),
+:host(.ui-button--secondary) {
+  --ui-button-color: var(--text-primary);
+  --ui-button-shadow: 0 12px 24px -22px rgba(15, 23, 42, 0.35);
+}
+
+:host(.ui-button--secondary) {
+  --ui-button-bg: var(--surface-muted);
+  --ui-button-border: rgba(15, 23, 42, 0.08);
+}
+
+:host(.ui-button--ghost) {
+  --ui-button-bg: rgba(255, 255, 255, 0.72);
+  --ui-button-border: rgba(15, 23, 42, 0.08);
+}
+
+:host(.ui-button--outline) {
+  --ui-button-bg: rgba(14, 165, 233, 0.08);
+  --ui-button-border: rgba(14, 165, 233, 0.45);
+  --ui-button-color: var(--accent-strong);
+  --ui-button-shadow: none;
+}
+
+:host(.ui-button--danger) {
+  --ui-button-bg: linear-gradient(135deg, rgba(244, 63, 94, 0.92), rgba(249, 115, 22, 0.92));
+  --ui-button-color: #fff;
+  --ui-button-border: transparent;
+  --ui-button-shadow: 0 18px 34px -20px rgba(244, 63, 94, 0.5);
+}
+
+:host(.ui-button--success) {
+  --ui-button-bg: linear-gradient(135deg, rgba(20, 184, 166, 0.92), rgba(59, 130, 246, 0.92));
+}
+
+:host(:hover) {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 44px -26px rgba(14, 165, 233, 0.55);
+}
+
+:host(.ui-button--ghost:hover) {
+  --ui-button-border: rgba(14, 165, 233, 0.35);
+  color: var(--accent-strong);
+}
+
+:host(.ui-button--outline:hover) {
+  --ui-button-bg: rgba(14, 165, 233, 0.12);
+  --ui-button-border: rgba(14, 165, 233, 0.55);
+}
+
+:host(.ui-button--secondary:hover) {
+  --ui-button-border: rgba(15, 23, 42, 0.14);
+}
+
+:host(.ui-button--danger:hover) {
+  box-shadow: 0 26px 48px -26px rgba(244, 63, 94, 0.45);
+}
+
+:host(.ui-button--static),
+:host(.ui-button--static:hover) {
+  transform: none;
+  box-shadow: var(--ui-button-shadow);
+}
+
+:host(:disabled),
+:host(.ui-button--disabled),
+:host([aria-disabled='true']) {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+:host(:focus-visible) {
+  outline: 3px solid rgba(14, 165, 233, 0.35);
+  outline-offset: 2px;
+}

--- a/src/app/ui/ui-button/ui-button.component.ts
+++ b/src/app/ui/ui-button/ui-button.component.ts
@@ -1,0 +1,64 @@
+import { Component, HostBinding, Input } from '@angular/core';
+
+export type UiButtonVariant = 'primary' | 'secondary' | 'ghost' | 'outline' | 'danger';
+export type UiButtonSize = 'sm' | 'md' | 'lg';
+
+@Component({
+  selector: 'button[uiButton], a[uiButton]',
+  standalone: true,
+  template: '<ng-content />',
+  styleUrls: ['./ui-button.component.scss']
+})
+export class UiButtonComponent {
+  private _variant: UiButtonVariant = 'primary';
+
+  @Input()
+  set uiButton(value: UiButtonVariant | '') {
+    this._variant = value === '' ? 'primary' : value;
+  }
+
+  get uiButton(): UiButtonVariant {
+    return this._variant;
+  }
+
+  @Input() uiButtonSize: UiButtonSize = 'md';
+  @Input() uiButtonTone: 'default' | 'success' = 'default';
+  @Input() uiButtonInteractive = true;
+
+  @HostBinding('class.ui-button') baseClass = true;
+  @HostBinding('class.ui-button--primary') get isPrimary(): boolean {
+    return this.uiButton === 'primary';
+  }
+
+  @HostBinding('class.ui-button--secondary') get isSecondary(): boolean {
+    return this.uiButton === 'secondary';
+  }
+
+  @HostBinding('class.ui-button--ghost') get isGhost(): boolean {
+    return this.uiButton === 'ghost';
+  }
+
+  @HostBinding('class.ui-button--outline') get isOutline(): boolean {
+    return this.uiButton === 'outline';
+  }
+
+  @HostBinding('class.ui-button--danger') get isDanger(): boolean {
+    return this.uiButton === 'danger';
+  }
+
+  @HostBinding('class.ui-button--sm') get isSmall(): boolean {
+    return this.uiButtonSize === 'sm';
+  }
+
+  @HostBinding('class.ui-button--lg') get isLarge(): boolean {
+    return this.uiButtonSize === 'lg';
+  }
+
+  @HostBinding('class.ui-button--success') get isSuccessTone(): boolean {
+    return this.uiButtonTone === 'success';
+  }
+
+  @HostBinding('class.ui-button--static') get isStatic(): boolean {
+    return !this.uiButtonInteractive;
+  }
+}

--- a/src/app/ui/ui-card/ui-card.component.scss
+++ b/src/app/ui/ui-card/ui-card.component.scss
@@ -1,0 +1,51 @@
+:host {
+  --ui-card-bg: var(--surface);
+  --ui-card-border: var(--border);
+  --ui-card-shadow: var(--shadow-soft);
+  --ui-card-color: inherit;
+  display: block;
+  border-radius: var(--radius-xl);
+  border: 1px solid var(--ui-card-border);
+  padding: clamp(1.2rem, 2.4vw, 1.9rem);
+  background: var(--ui-card-bg);
+  box-shadow: var(--ui-card-shadow);
+  color: var(--ui-card-color);
+  backdrop-filter: blur(20px);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+:host(.ui-card--sm) {
+  padding: clamp(1rem, 1.6vw, 1.4rem);
+}
+
+:host(.ui-card--lg) {
+  padding: clamp(1.6rem, 3vw, 2.4rem);
+}
+
+:host(.ui-card--muted) {
+  --ui-card-bg: var(--surface-muted);
+  --ui-card-border: rgba(15, 23, 42, 0.08);
+}
+
+:host(.ui-card--surface) {
+  --ui-card-bg: var(--surface);
+  --ui-card-border: rgba(148, 163, 184, 0.2);
+  --ui-card-shadow: 0 24px 45px -32px rgba(15, 23, 42, 0.15);
+}
+
+:host(.ui-card--gradient) {
+  --ui-card-bg: linear-gradient(145deg, rgba(14, 165, 233, 0.12), rgba(59, 130, 246, 0.08) 48%, rgba(16, 185, 129, 0.18));
+  --ui-card-border: rgba(14, 165, 233, 0.35);
+  --ui-card-shadow: 0 28px 52px -30px rgba(14, 165, 233, 0.28);
+}
+
+:host(:hover) {
+  transform: translateY(-3px);
+  box-shadow: 0 32px 60px -32px rgba(15, 23, 42, 0.2);
+}
+
+:host(.ui-card--static),
+:host(.ui-card--static:hover) {
+  transform: none;
+  box-shadow: var(--ui-card-shadow);
+}

--- a/src/app/ui/ui-card/ui-card.component.ts
+++ b/src/app/ui/ui-card/ui-card.component.ts
@@ -1,0 +1,45 @@
+import { Component, HostBinding, Input } from '@angular/core';
+
+export type UiCardVariant = 'elevated' | 'muted' | 'surface' | 'gradient';
+export type UiCardPadding = 'sm' | 'md' | 'lg';
+
+@Component({
+  selector: 'ui-card',
+  standalone: true,
+  template: '<ng-content />',
+  styleUrls: ['./ui-card.component.scss']
+})
+export class UiCardComponent {
+  @Input() uiCardVariant: UiCardVariant = 'elevated';
+  @Input() uiCardPadding: UiCardPadding = 'md';
+  @Input() uiCardInteractive = true;
+
+  @HostBinding('class.ui-card') baseClass = true;
+  @HostBinding('class.ui-card--elevated') get isElevated(): boolean {
+    return this.uiCardVariant === 'elevated';
+  }
+
+  @HostBinding('class.ui-card--muted') get isMuted(): boolean {
+    return this.uiCardVariant === 'muted';
+  }
+
+  @HostBinding('class.ui-card--surface') get isSurface(): boolean {
+    return this.uiCardVariant === 'surface';
+  }
+
+  @HostBinding('class.ui-card--gradient') get isGradient(): boolean {
+    return this.uiCardVariant === 'gradient';
+  }
+
+  @HostBinding('class.ui-card--sm') get isSmallPadding(): boolean {
+    return this.uiCardPadding === 'sm';
+  }
+
+  @HostBinding('class.ui-card--lg') get isLargePadding(): boolean {
+    return this.uiCardPadding === 'lg';
+  }
+
+  @HostBinding('class.ui-card--static') get isStatic(): boolean {
+    return !this.uiCardInteractive;
+  }
+}

--- a/src/app/ui/ui-input/ui-input.component.scss
+++ b/src/app/ui/ui-input/ui-input.component.scss
@@ -1,0 +1,52 @@
+:host {
+  width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  padding: 0.75rem 1rem;
+  font-size: 0.95rem;
+  background: rgba(246, 248, 253, 0.9);
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+:host(.ui-input--sm) {
+  padding: 0.6rem 0.85rem;
+  font-size: 0.85rem;
+}
+
+:host(.ui-input--lg) {
+  padding: 0.95rem 1.2rem;
+  font-size: 1rem;
+}
+
+:host(.ui-input--textarea) {
+  min-height: 120px;
+  resize: vertical;
+}
+
+:host(.ui-input--select) {
+  appearance: none;
+  padding-right: 2.6rem;
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="12" height="8" viewBox="0 0 12 8" fill="none"%3E%3Cpath d="M1 1.5L6 6.5L11 1.5" stroke="%230f172a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/%3E%3C/svg%3E');
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  background-size: 0.85rem;
+}
+
+:host(:focus) {
+  border-color: rgba(14, 165, 233, 0.65);
+  background: #fff;
+  box-shadow: 0 0 0 4px rgba(14, 165, 233, 0.12);
+  outline: none;
+}
+
+:host(.ui-input--disabled) {
+  background: rgba(148, 163, 184, 0.08);
+  color: rgba(15, 23, 42, 0.45);
+  cursor: not-allowed;
+}
+
+:host::placeholder {
+  color: rgba(15, 23, 42, 0.35);
+}

--- a/src/app/ui/ui-input/ui-input.component.ts
+++ b/src/app/ui/ui-input/ui-input.component.ts
@@ -1,0 +1,38 @@
+import { Component, ElementRef, HostBinding, Input } from '@angular/core';
+
+export type UiInputSize = 'sm' | 'md' | 'lg';
+type UiInputElement = HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement;
+
+@Component({
+  selector: 'input[uiInput], textarea[uiInput], select[uiInput]',
+  standalone: true,
+  template: '',
+  styleUrls: ['./ui-input.component.scss']
+})
+
+export class UiInputComponent {
+  @Input() uiInputSize: UiInputSize = 'md';
+
+  constructor(private readonly elementRef: ElementRef<UiInputElement>) {}
+
+  @HostBinding('class.ui-input') baseClass = true;
+  @HostBinding('class.ui-input--sm') get isSmall(): boolean {
+    return this.uiInputSize === 'sm';
+  }
+
+  @HostBinding('class.ui-input--lg') get isLarge(): boolean {
+    return this.uiInputSize === 'lg';
+  }
+
+  @HostBinding('class.ui-input--textarea') get isTextarea(): boolean {
+    return this.elementRef.nativeElement.tagName === 'TEXTAREA';
+  }
+
+  @HostBinding('class.ui-input--select') get isSelect(): boolean {
+    return this.elementRef.nativeElement.tagName === 'SELECT';
+  }
+
+  @HostBinding('class.ui-input--disabled') get isDisabled(): boolean {
+    return this.elementRef.nativeElement.disabled;
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -80,27 +80,6 @@ img {
   margin-inline: auto;
 }
 
-.card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-xl);
-  padding: clamp(1.3rem, 2.4vw, 1.9rem);
-  box-shadow: var(--shadow-soft);
-  backdrop-filter: blur(18px);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 32px 60px -32px rgba(15, 23, 42, 0.22);
-}
-
-.card-title {
-  font-size: clamp(1.05rem, 1.7vw, 1.3rem);
-  font-weight: 700;
-  margin-bottom: 0.35rem;
-}
-
 .muted {
   color: var(--text-muted);
 }
@@ -108,68 +87,6 @@ img {
 .strong {
   font-weight: 600;
   color: var(--text-primary);
-}
-
-.btn,
-button.btn,
-a.btn,
-button.ghost,
-a.ghost {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  border-radius: var(--radius-md);
-  border: 1px solid transparent;
-  font-weight: 600;
-  font-size: 0.95rem;
-  padding: 0.65rem 1.2rem;
-  transition: var(--transition);
-  cursor: pointer;
-}
-
-.btn,
-button.btn,
-a.btn {
-  background: linear-gradient(135deg, rgba(14, 165, 233, 0.95), rgba(16, 185, 129, 0.92));
-  color: #fff;
-  border-color: transparent;
-  box-shadow: 0 16px 30px -20px rgba(14, 165, 233, 0.6);
-}
-
-.btn:hover,
-button.btn:hover,
-a.btn:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 24px 44px -26px rgba(14, 165, 233, 0.55);
-}
-
-.btn--small {
-  padding: 0.45rem 0.85rem;
-  font-size: 0.85rem;
-}
-
-.btn.primary,
-button.primary,
-a.primary {
-  background: linear-gradient(135deg, rgba(14, 165, 233, 0.95), rgba(16, 185, 129, 0.95));
-  box-shadow: 0 18px 34px -20px rgba(16, 185, 129, 0.65);
-}
-
-.btn.ghost,
-button.ghost,
-a.ghost {
-  background: rgba(255, 255, 255, 0.65);
-  border-color: rgba(15, 23, 42, 0.08);
-  color: var(--text-primary);
-  box-shadow: 0 12px 24px -22px rgba(15, 23, 42, 0.6);
-}
-
-.btn.ghost:hover,
-button.ghost:hover,
-a.ghost:hover {
-  border-color: rgba(13, 148, 136, 0.45);
-  color: rgba(13, 148, 136, 0.95);
 }
 
 label {
@@ -237,121 +154,6 @@ input[type='file']::file-selector-button {
 input[type='file']::file-selector-button:hover {
   transform: translateY(-1px);
   box-shadow: 0 16px 32px -22px rgba(6, 182, 212, 0.55);
-}
-
-.form-section {
-  display: grid;
-  gap: 1.4rem;
-}
-
-.form-card {
-  position: relative;
-  padding: clamp(1.1rem, 2vw, 1.5rem);
-  border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: var(--surface-elevated);
-  box-shadow: 0 24px 45px -32px rgba(15, 23, 42, 0.2);
-  overflow: hidden;
-}
-
-.form-card__remove {
-  position: absolute;
-  top: 0.85rem;
-  right: 0.85rem;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  border-radius: 999px;
-  border: 1px solid rgba(239, 68, 68, 0.2);
-  background: rgba(254, 226, 226, 0.45);
-  color: rgba(220, 38, 38, 0.85);
-  transition: var(--transition);
-}
-
-.form-card__remove:hover {
-  background: rgba(248, 113, 113, 0.25);
-  border-color: rgba(239, 68, 68, 0.35);
-  transform: translateY(-1px);
-}
-
-.form-grid {
-  display: grid;
-  gap: 1.1rem;
-}
-
-@media (min-width: 520px) {
-  .form-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 880px) {
-  .form-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-.form-grid--meta {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-}
-
-.form-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.45rem;
-}
-
-.form-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: rgba(15, 23, 42, 0.75);
-}
-
-.form-hint {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-
-.form-control {
-  width: 100%;
-  border-radius: var(--radius-sm);
-  border: 1px solid var(--border);
-  padding: 0.75rem 1rem;
-  background: var(--surface-muted);
-  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-}
-
-.form-control:focus {
-  border-color: rgba(14, 165, 233, 0.65);
-  background: #fff;
-  box-shadow: 0 0 0 4px rgba(14, 165, 233, 0.12);
-  outline: none;
-}
-
-.form-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-}
-
-.link-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-weight: 600;
-  color: var(--accent-strong);
-  font-size: 0.9rem;
-  padding: 0.35rem 0.25rem;
-  border-radius: 999px;
-  transition: color 0.2s ease, transform 0.2s ease;
-}
-
-.link-button:hover {
-  color: var(--accent);
-  transform: translateY(-1px);
 }
 
 .table-wrapper {
@@ -511,16 +313,13 @@ input[type='file']::file-selector-button:hover {
 }
 
 @media (max-width: 600px) {
-  .card {
+  ui-card {
     border-radius: 1rem;
     padding: 1.1rem;
   }
 
-  .btn,
-  button.btn,
-  a.btn,
-  button.ghost,
-  a.ghost {
+  button[uiButton],
+  a[uiButton] {
     width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- add reusable UiButton, UiCard, and UiInput primitives to centralize theme-aware styling
- redesign the inventory quick editor and storage summary cards with richer layouts and shared controls
- migrate product forms, imports, receipts, and sales/storage shells to the new UI system for a consistent surface

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d136a595d483248ea1be221ae1dacd