### PR TITLE
Implement Supabase session management and route guards

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,14 +1,23 @@
-<div class="app-shell">
-  <app-nav></app-nav>
-
-  <main class="app-main" role="main">
-    <router-outlet></router-outlet>
-  </main>
-
-  <footer class="app-footer" role="contentinfo">
-    <div class="footer-inner">
-      <span class="footer-brand">Hassib POS Suite</span>
-      <span class="footer-copy">Built for fast retail operations and accurate inventory.</span>
+@if (authState().status === 'loading') {
+  <div class="app-shell loading-state">
+    <div class="loading-indicator" role="status" aria-live="polite">
+      <span class="spinner" aria-hidden="true"></span>
+      <span>Restoring your session…</span>
     </div>
-  </footer>
-</div>
+  </div>
+} @else {
+  <div class="app-shell">
+    <app-nav></app-nav>
+
+    <main class="app-main" role="main">
+      <router-outlet></router-outlet>
+    </main>
+
+    <footer class="app-footer" role="contentinfo">
+      <div class="footer-inner">
+        <span class="footer-brand">Hassib POS Suite</span>
+        <span class="footer-copy">Built for fast retail operations and accurate inventory.</span>
+      </div>
+    </footer>
+  </div>
+}

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -7,6 +7,38 @@
               linear-gradient(180deg, rgba(248, 250, 252, 0.9), rgba(241, 245, 249, 0.85));
 }
 
+.app-shell.loading-state {
+  align-items: center;
+  justify-content: center;
+}
+
+.loading-indicator {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 1.5rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  color: rgba(15, 23, 42, 0.75);
+  font-weight: 500;
+}
+
+.loading-indicator .spinner {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  border: 3px solid rgba(14, 165, 233, 0.2);
+  border-top-color: rgba(14, 165, 233, 0.75);
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .app-main {
   flex: 1;
   padding: clamp(1.5rem, 3vw, 3rem) clamp(1rem, 4vw, 4rem);

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,12 +1,48 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BehaviorSubject } from 'rxjs';
 
 import { AppComponent } from './app.component';
+import { AuthService } from './shared/services/auth.service';
+import { AuthState, UserStoreService } from './shared/services/user-store.service';
+
+class UserStoreMock {
+  private readonly subject: BehaviorSubject<AuthState>;
+  readonly state$;
+  snapshot: AuthState;
+
+  constructor(initial: AuthState) {
+    this.subject = new BehaviorSubject<AuthState>(initial);
+    this.state$ = this.subject.asObservable();
+    this.snapshot = initial;
+  }
+
+  setState(state: AuthState) {
+    this.snapshot = state;
+    this.subject.next(state);
+  }
+}
 
 describe('AppComponent', () => {
+  let userStore: UserStoreMock;
+  let authService: { restoreSession: jest.Mock };
+
   beforeEach(async () => {
+    userStore = new UserStoreMock({
+      status: 'loading',
+      session: null,
+      user: null,
+      roles: [],
+      error: null,
+    });
+    authService = { restoreSession: jest.fn().mockResolvedValue(undefined) };
+
     await TestBed.configureTestingModule({
       imports: [AppComponent, RouterTestingModule],
+      providers: [
+        { provide: UserStoreService, useValue: userStore },
+        { provide: AuthService, useValue: authService },
+      ],
     }).compileComponents();
   });
 
@@ -16,8 +52,25 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render the navigation shell', () => {
+  it('shows a loading indicator while restoring the session', () => {
     const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.loading-indicator')).not.toBeNull();
+  });
+
+  it('renders the shell once the session is available', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+
+    userStore.setState({
+      status: 'authenticated',
+      session: {} as any,
+      user: { id: 'user-1', email: 'demo@example.com' },
+      roles: ['user'],
+      error: null,
+    });
+
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
     expect(compiled.querySelector('app-nav')).not.toBeNull();

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, OnInit, inject } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+
 import { NavComponent } from './components/navbar/navbar.component';
+import { AuthService } from './shared/services/auth.service';
+import { UserStoreService } from './shared/services/user-store.service';
+
 @Component({
   selector: 'app-root',
   standalone: true,
@@ -8,4 +13,15 @@ import { NavComponent } from './components/navbar/navbar.component';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
-export class AppComponent {}
+export class AppComponent implements OnInit {
+  private readonly authService = inject(AuthService);
+  private readonly userStore = inject(UserStoreService);
+
+  readonly authState = toSignal(this.userStore.state$, {
+    initialValue: this.userStore.snapshot,
+  });
+
+  ngOnInit(): void {
+    void this.authService.restoreSession();
+  }
+}

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,7 @@
 import { Routes } from '@angular/router';
 
+import { AuthGuard } from './shared/guards/auth.guard';
+
 export const routes: Routes = [
   {
     path: '',
@@ -19,10 +21,14 @@ export const routes: Routes = [
   },
   {
     path: 'sales',
+    canActivate: [AuthGuard],
+    data: { roles: ['admin', 'user'] },
     loadComponent: () => import('./pages/sales-page/sales-page.component').then(m => m.SalesPage)
   },
   {
     path: 'storage',
+    canActivate: [AuthGuard],
+    data: { roles: ['admin'] },
     loadComponent: () => import('./pages/storage-page/storage-page.component').then(m => m.StoragePage)
   },
   {

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -30,6 +30,7 @@
             routerLinkActive="active"
             [routerLinkActiveOptions]="{ exact: link.exact ?? false }"
             (click)="closeMenu()"
+            [attr.aria-disabled]="!isAuthenticated() && link.route !== '/' && link.route !== '/landing' ? true : null"
           >
             <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
               <path
@@ -43,22 +44,38 @@
           </a>
         }
       </div>
-      <button
-        type="button"
-        class="sign-out"
-        (click)="signOut()"
-        [disabled]="signingOut()"
-      >
-        <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
-          <path
-            d="M16 17l5-5-5-5M21 12H9M12 19a7 7 0 110-14"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          />
-        </svg>
-        <span>{{ signingOut() ? 'Signing Out…' : 'Sign Out' }}</span>
-      </button>
+
+      @if (isAuthenticated()) {
+        <div class="account-controls">
+          <span class="user-pill" aria-live="polite">
+            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path
+                d="M12 14c3.866 0 7 3.134 7 7H5c0-3.866 3.134-7 7-7zm0-2a4 4 0 100-8 4 4 0 000 8z"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <span>{{ userEmail() || 'Authenticated User' }}</span>
+          </span>
+          <button type="button" class="sign-out" (click)="signOut()" [disabled]="signingOut()">
+            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path
+                d="M16 17l5-5-5-5M21 12H9M12 19a7 7 0 110-14"
+                stroke-width="1.5"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              />
+            </svg>
+            <span>{{ signingOut() ? 'Signing Out…' : 'Sign Out' }}</span>
+          </button>
+        </div>
+      } @else {
+        <div class="auth-links">
+          <a class="login" routerLink="/login" (click)="closeMenu()">Sign In</a>
+          <a class="register" routerLink="/sign-up" (click)="closeMenu()">Create account</a>
+        </div>
+      }
     </div>
   </div>
 

--- a/src/app/components/navbar/navbar.component.scss
+++ b/src/app/components/navbar/navbar.component.scss
@@ -104,6 +104,11 @@
   gap: 0.5rem;
 }
 
+.nav-link[aria-disabled='true'] {
+  opacity: 0.45;
+  pointer-events: none;
+}
+
 .nav-link {
   position: relative;
   display: inline-flex;
@@ -127,6 +132,24 @@
   color: rgba(15, 23, 42, 0.95);
   background: rgba(20, 184, 166, 0.16);
   box-shadow: inset 0 0 0 1px rgba(20, 184, 166, 0.35);
+}
+
+.account-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.user-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(14, 116, 144, 0.08);
+  color: rgba(15, 23, 42, 0.8);
+  font-size: 0.85rem;
+  font-weight: 500;
 }
 
 .sign-out {
@@ -157,6 +180,37 @@
   opacity: 0.75;
   transform: none;
   box-shadow: none;
+}
+
+.auth-links {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.auth-links a {
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.55rem 1rem;
+  border-radius: 0.75rem;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.auth-links .login {
+  color: rgba(15, 23, 42, 0.75);
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.auth-links .register {
+  color: #fff;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  box-shadow: 0 12px 24px -18px rgba(37, 99, 235, 0.6);
+}
+
+.auth-links a:hover,
+.auth-links a:focus-visible {
+  outline: none;
+  filter: brightness(0.95);
 }
 
 .sign-out-error {
@@ -207,6 +261,23 @@
     justify-content: center;
     margin-top: 0.75rem;
     margin-left: 0;
+  }
+
+  .account-controls {
+    width: 100%;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .auth-links {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .auth-links a,
+  .user-pill {
+    width: 100%;
+    justify-content: center;
   }
 }
 

--- a/src/app/components/navbar/navbar.component.spec.ts
+++ b/src/app/components/navbar/navbar.component.spec.ts
@@ -1,23 +1,83 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
+import { BehaviorSubject } from 'rxjs';
 
 import { NavComponent } from './navbar.component';
+import { AuthService } from '../../shared/services/auth.service';
+import { AuthState, UserStoreService } from '../../shared/services/user-store.service';
+
+class UserStoreMock {
+  private readonly subject: BehaviorSubject<AuthState>;
+  readonly state$; 
+  snapshot: AuthState;
+
+  constructor(initial: AuthState) {
+    this.subject = new BehaviorSubject<AuthState>(initial);
+    this.state$ = this.subject.asObservable();
+    this.snapshot = initial;
+  }
+
+  setState(state: AuthState) {
+    this.snapshot = state;
+    this.subject.next(state);
+  }
+}
 
 describe('NavbarComponent', () => {
   let component: NavComponent;
   let fixture: ComponentFixture<NavComponent>;
+  let authService: { signOut: jest.Mock };
+  let userStore: UserStoreMock;
+  let router: Router;
 
   beforeEach(async () => {
+    authService = { signOut: jest.fn().mockResolvedValue(undefined) };
+    userStore = new UserStoreMock({
+      status: 'unauthenticated',
+      session: null,
+      user: null,
+      roles: [],
+      error: null,
+    });
+
     await TestBed.configureTestingModule({
       imports: [NavComponent, RouterTestingModule],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        { provide: UserStoreService, useValue: userStore },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(NavComponent);
     component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate').mockResolvedValue(true as any);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  it('shows sign-in links when unauthenticated', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.auth-links .login')?.textContent).toContain('Sign In');
+  });
+
+  it('displays the user email and sign-out button when authenticated', async () => {
+    userStore.setState({
+      status: 'authenticated',
+      session: {} as any,
+      user: { id: 'user-1', email: 'demo@example.com' },
+      roles: ['user'],
+      error: null,
+    });
+
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.user-pill')?.textContent).toContain('demo@example.com');
+
+    const signOutButton = compiled.querySelector<HTMLButtonElement>('button.sign-out');
+    signOutButton?.click();
+
+    expect(authService.signOut).toHaveBeenCalled();
   });
 });

--- a/src/app/pages/login-page/login-page.component.spec.ts
+++ b/src/app/pages/login-page/login-page.component.spec.ts
@@ -1,0 +1,64 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { convertToParamMap } from '@angular/router';
+
+import { LoginPageComponent } from './login-page.component';
+import { AuthService } from '../../shared/services/auth.service';
+
+describe('LoginPageComponent', () => {
+  let fixture: ComponentFixture<LoginPageComponent>;
+  let component: LoginPageComponent;
+  let authService: {
+    signIn: jest.Mock;
+    loading: jest.Mock;
+    error: jest.Mock;
+    configurationError: jest.Mock;
+    isConfigured: jest.Mock;
+  };
+  let router: Router;
+
+  beforeEach(async () => {
+    authService = {
+      signIn: jest.fn().mockResolvedValue(undefined),
+      loading: jest.fn(() => signal(false)),
+      error: jest.fn(() => signal<string | null>(null)),
+      configurationError: jest.fn(() => signal<string | null>(null)),
+      isConfigured: jest.fn(() => true),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [LoginPageComponent, RouterTestingModule],
+      providers: [
+        { provide: AuthService, useValue: authService },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { queryParamMap: convertToParamMap({ returnUrl: '/storage' }) },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoginPageComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    jest.spyOn(router, 'navigate').mockResolvedValue(true as any);
+    fixture.detectChanges();
+  });
+
+  it('does not submit when the form is invalid', async () => {
+    component.submit();
+    expect(authService.signIn).not.toHaveBeenCalled();
+  });
+
+  it('signs in and redirects to the return url', async () => {
+    component.form.setValue({ email: 'demo@example.com', password: 'password123', remember: false });
+
+    await component.submit();
+
+    expect(authService.signIn).toHaveBeenCalledWith('demo@example.com', 'password123');
+    expect(router.navigate).toHaveBeenCalledWith(['/storage']);
+  });
+});

--- a/src/app/pages/login-page/login-page.component.ts
+++ b/src/app/pages/login-page/login-page.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 
 import { AuthService } from '../../shared/services/auth.service';
@@ -15,6 +15,7 @@ export class LoginPageComponent {
   private readonly fb = inject(FormBuilder);
   private readonly auth = inject(AuthService);
   private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
 
   readonly form = this.fb.group({
     email: ['', [Validators.required, Validators.email]],
@@ -63,8 +64,9 @@ export class LoginPageComponent {
     try {
       await this.auth.signIn(email, password);
       this.successMessage.set('Signed in successfully. You can proceed to your dashboard.');
-      // Navigate to the sales workspace for convenience
-      void this.router.navigate(['/sales']);
+      const returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
+      const target = returnUrl && returnUrl.startsWith('/') ? returnUrl : '/sales';
+      void this.router.navigate([target]);
     } catch (error) {
       // Error state already captured by the auth service; nothing else required.
       console.error('Failed to sign in with Supabase', error);

--- a/src/app/shared/guards/auth.guard.spec.ts
+++ b/src/app/shared/guards/auth.guard.spec.ts
@@ -1,0 +1,96 @@
+import { Router } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+import { firstValueFrom, Subject } from 'rxjs';
+
+import { AuthGuard } from './auth.guard';
+import { AuthService } from '../services/auth.service';
+import { AuthState, UserStoreService } from '../services/user-store.service';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let navigateUrl: string | undefined;
+  let state$: Subject<AuthState>;
+
+  beforeEach(() => {
+    navigateUrl = undefined;
+    state$ = new Subject<AuthState>();
+
+    const authServiceMock = { restoreSession: jest.fn().mockResolvedValue(undefined) };
+    const userStoreMock: Partial<UserStoreService> = {
+      state$: state$.asObservable(),
+      snapshot: { status: 'loading', session: null, user: null, roles: [], error: null },
+      hasRequiredRole: jest.fn().mockReturnValue(true),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthGuard,
+        { provide: AuthService, useValue: authServiceMock },
+        { provide: UserStoreService, useValue: userStoreMock },
+        {
+          provide: Router,
+          useValue: {
+            createUrlTree: jest.fn().mockImplementation(url => {
+              navigateUrl = Array.isArray(url) ? url.join('/') : url;
+              return `tree:${navigateUrl}`;
+            }),
+          },
+        },
+      ],
+    });
+
+    guard = TestBed.inject(AuthGuard);
+  });
+
+  it('redirects unauthenticated users to login with return url', async () => {
+    const resultPromise = firstValueFrom(
+      guard.canActivate({ data: {} } as any, { url: '/secure' } as any),
+    );
+
+    state$.next({ status: 'unauthenticated', session: null, user: null, roles: [], error: null });
+
+    const result = await resultPromise;
+    expect(result).toBe('tree:/login');
+    expect(navigateUrl).toBe('/login');
+  });
+
+  it('blocks access when required roles are missing', async () => {
+    const userStore = TestBed.inject(UserStoreService) as any;
+    userStore.hasRequiredRole.mockReturnValue(false);
+
+    const session: any = { user: { id: 'user-1' } };
+    const resultPromise = firstValueFrom(
+      guard.canActivate({ data: { roles: ['admin'] } } as any, { url: '/admin' } as any),
+    );
+
+    state$.next({
+      status: 'authenticated',
+      session,
+      user: { id: 'user-1', email: 'demo@example.com' },
+      roles: ['user'],
+      error: null,
+    });
+
+    const result = await resultPromise;
+    expect(result).toBe('tree:/');
+    expect(navigateUrl).toBe('/');
+  });
+
+  it('allows access for authenticated users with a matching role', async () => {
+    const session: any = { user: { id: 'user-1' } };
+    const resultPromise = firstValueFrom(
+      guard.canActivate({ data: { roles: ['user'] } } as any, { url: '/sales' } as any),
+    );
+
+    state$.next({
+      status: 'authenticated',
+      session,
+      user: { id: 'user-1', email: 'demo@example.com' },
+      roles: ['user'],
+      error: null,
+    });
+
+    const result = await resultPromise;
+    expect(result).toBe(true);
+  });
+});

--- a/src/app/shared/guards/auth.guard.ts
+++ b/src/app/shared/guards/auth.guard.ts
@@ -1,0 +1,48 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  CanActivate,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { Observable } from 'rxjs';
+import { filter, map, take } from 'rxjs/operators';
+
+import { AuthService } from '../services/auth.service';
+import { UserStoreService } from '../services/user-store.service';
+
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  private readonly authService = inject(AuthService);
+  private readonly userStore = inject(UserStoreService);
+  private readonly router = inject(Router);
+
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    routerState: RouterStateSnapshot,
+  ): Observable<boolean | UrlTree> {
+    void this.authService.restoreSession();
+
+    const requiredRoles = route.data?.['roles'] as readonly string[] | undefined;
+    const returnUrl = routerState.url;
+
+    return this.userStore.state$.pipe(
+      filter(authState => authState.status !== 'loading'),
+      take(1),
+      map(authState => {
+        if (authState.status !== 'authenticated' || !authState.session) {
+          return this.router.createUrlTree(['/login'], {
+            queryParams: { returnUrl },
+          });
+        }
+
+        if (!this.userStore.hasRequiredRole(requiredRoles)) {
+          return this.router.createUrlTree(['/']);
+        }
+
+        return true;
+      }),
+    );
+  }
+}

--- a/src/app/shared/services/auth.service.spec.ts
+++ b/src/app/shared/services/auth.service.spec.ts
@@ -1,0 +1,117 @@
+import { TestBed } from '@angular/core/testing';
+import type { AuthSession } from '@supabase/supabase-js';
+
+import { AuthService } from './auth.service';
+import { SupabaseService } from './supabase.service';
+import { UserStoreService } from './user-store.service';
+
+const createSession = (overrides: Partial<AuthSession> = {}): AuthSession => ({
+  access_token: 'token',
+  expires_at: null,
+  expires_in: 3600,
+  refresh_token: 'refresh',
+  token_type: 'bearer',
+  provider_token: null,
+  provider_refresh_token: null,
+  user: {
+    id: 'user-1',
+    email: 'demo@example.com',
+    app_metadata: { roles: ['user'] },
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2024-01-01T00:00:00.000Z',
+    role: 'authenticated',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    identities: [],
+    last_sign_in_at: '2024-01-01T00:00:00.000Z',
+    factors: [],
+    phone: '',
+  },
+  ...overrides,
+});
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let supabaseClientMock: any;
+  let userStore: UserStoreService;
+  let authStateChangeHandler: ((event: string, session: AuthSession | null) => void) | null;
+
+  beforeEach(() => {
+    authStateChangeHandler = null;
+    supabaseClientMock = {
+      auth: {
+        getSession: jest.fn().mockResolvedValue({ data: { session: null }, error: null }),
+        signInWithPassword: jest.fn().mockResolvedValue({ data: {}, error: null }),
+        signUp: jest.fn().mockResolvedValue({ data: {}, error: null }),
+        signOut: jest.fn().mockResolvedValue({ error: null }),
+        onAuthStateChange: jest.fn().mockImplementation(handler => {
+          authStateChangeHandler = handler;
+          return { data: { subscription: { unsubscribe: jest.fn() } } };
+        }),
+      },
+    };
+
+    const supabaseServiceMock = {
+      isConfigured: jest.fn().mockReturnValue(true),
+      ensureClient: jest.fn().mockReturnValue(supabaseClientMock),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuthService,
+        UserStoreService,
+        { provide: SupabaseService, useValue: supabaseServiceMock },
+      ],
+    });
+
+    service = TestBed.inject(AuthService);
+    userStore = TestBed.inject(UserStoreService);
+  });
+
+  it('restores the current session on startup', async () => {
+    const session = createSession();
+    supabaseClientMock.auth.getSession.mockResolvedValue({ data: { session }, error: null });
+
+    await service.restoreSession();
+
+    expect(userStore.snapshot.status).toBe('authenticated');
+    expect(userStore.snapshot.session).toEqual(session);
+  });
+
+  it('updates the user store after successful sign in', async () => {
+    const session = createSession();
+    supabaseClientMock.auth.getSession
+      .mockResolvedValueOnce({ data: { session: null }, error: null })
+      .mockResolvedValue({ data: { session }, error: null });
+
+    await service.restoreSession();
+    await service.signIn('demo@example.com', 'password123');
+
+    expect(supabaseClientMock.auth.signInWithPassword).toHaveBeenCalledWith({
+      email: 'demo@example.com',
+      password: 'password123',
+    });
+    expect(userStore.snapshot.status).toBe('authenticated');
+    expect(userStore.snapshot.roles).toContain('user');
+  });
+
+  it('clears the session after sign out', async () => {
+    userStore.setSession(createSession());
+
+    await service.signOut();
+
+    expect(supabaseClientMock.auth.signOut).toHaveBeenCalled();
+    expect(userStore.snapshot.status).toBe('unauthenticated');
+  });
+
+  it('responds to Supabase auth state changes', async () => {
+    await service.restoreSession();
+
+    expect(authStateChangeHandler).toBeTruthy();
+
+    const session = createSession({ user: { ...createSession().user, email: 'new@example.com' } });
+    authStateChangeHandler?.('SIGNED_IN', session);
+
+    expect(userStore.snapshot.user).toEqual({ id: 'user-1', email: 'new@example.com' });
+  });
+});

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Signal, inject, signal } from '@angular/core';
-import type { Session } from '@supabase/supabase-js';
+import { DestroyRef, Injectable, Signal, inject, signal } from '@angular/core';
+import type { AuthChangeEvent, AuthSession } from '@supabase/supabase-js';
 
 import { SupabaseService } from './supabase.service';
+import { UserStoreService } from './user-store.service';
 
 interface SignUpPayload {
   email: string;
@@ -9,28 +10,27 @@ interface SignUpPayload {
   metadata?: Record<string, unknown>;
 }
 
+type SupabaseAuthSubscription = { unsubscribe: () => void };
+
 @Injectable({ providedIn: 'root' })
+
 export class AuthService {
   private readonly supabase = inject(SupabaseService);
+  private readonly userStore = inject(UserStoreService);
+  private readonly destroyRef = inject(DestroyRef);
 
-  private readonly sessionSignal = signal<Session | null>(null);
   private readonly loadingSignal = signal<boolean>(false);
   private readonly errorSignal = signal<string | null>(null);
+
+  private authSubscription: SupabaseAuthSubscription | null = null;
+  private initialisePromise: Promise<void> | null = null;
 
   constructor() {
     if (!this.supabase.isConfigured()) {
       return;
     }
 
-    const client = this.supabase.ensureClient();
-
-    void client.auth.getSession().then(({ data }) => {
-      this.sessionSignal.set(data.session ?? null);
-    });
-
-    client.auth.onAuthStateChange((_event, session) => {
-      this.sessionSignal.set(session);
-    });
+    void this.restoreSession();
   }
 
   isConfigured(): boolean {
@@ -41,16 +41,76 @@ export class AuthService {
     return this.supabase.configurationError();
   }
 
-  session(): Signal<Session | null> {
-    return this.sessionSignal.asReadonly();
-  }
-
   loading(): Signal<boolean> {
     return this.loadingSignal.asReadonly();
   }
 
   error(): Signal<string | null> {
     return this.errorSignal.asReadonly();
+  }
+
+  async restoreSession(): Promise<void> {
+    if (!this.supabase.isConfigured()) {
+      this.userStore.setSession(null);
+      return;
+    }
+
+    if (this.initialisePromise) {
+      return this.initialisePromise;
+    }
+
+    this.initialisePromise = this.initialiseAuth();
+    try {
+      await this.initialisePromise;
+    } finally {
+      this.initialisePromise = null;
+    }
+  }
+
+  private async initialiseAuth(): Promise<void> {
+    const client = this.supabase.ensureClient();
+    this.userStore.setLoading();
+
+    try {
+      const { data, error } = await client.auth.getSession();
+      if (error) {
+        throw error;
+      }
+      this.userStore.setSession(data.session ?? null);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : 'Unable to restore Supabase session.';
+      this.userStore.setSession(null);
+      this.userStore.setError(message);
+    }
+
+    if (!this.authSubscription) {
+      const {
+        data: { subscription },
+      } = client.auth.onAuthStateChange((_event: AuthChangeEvent, session: AuthSession | null) => {
+        this.userStore.setSession(session);
+      });
+
+      this.authSubscription = subscription;
+      this.destroyRef.onDestroy(() => {
+        this.authSubscription?.unsubscribe();
+        this.authSubscription = null;
+      });
+    }
+  }
+
+  async refreshSession(): Promise<void> {
+    if (!this.supabase.isConfigured()) {
+      this.userStore.setSession(null);
+      return;
+    }
+
+    const client = this.supabase.ensureClient();
+    const { data, error } = await client.auth.getSession();
+    if (error) {
+      throw error;
+    }
+    this.userStore.setSession(data.session ?? null);
   }
 
   async signIn(email: string, password: string): Promise<void> {
@@ -60,6 +120,7 @@ export class AuthService {
 
     this.loadingSignal.set(true);
     this.errorSignal.set(null);
+    this.userStore.clearError();
 
     try {
       const client = this.supabase.ensureClient();
@@ -67,9 +128,11 @@ export class AuthService {
       if (error) {
         throw error;
       }
+      await this.refreshSession();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to sign in with Supabase.';
       this.errorSignal.set(message);
+      this.userStore.setError(message);
       throw new Error(message);
     } finally {
       this.loadingSignal.set(false);
@@ -95,9 +158,11 @@ export class AuthService {
       if (error) {
         throw error;
       }
+      await this.refreshSession();
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to create Supabase user.';
       this.errorSignal.set(message);
+      this.userStore.setError(message);
       throw new Error(message);
     } finally {
       this.loadingSignal.set(false);
@@ -106,7 +171,7 @@ export class AuthService {
 
   async signOut(): Promise<void> {
     if (!this.supabase.isConfigured()) {
-      this.sessionSignal.set(null);
+      this.userStore.setSession(null);
       return;
     }
 
@@ -115,6 +180,6 @@ export class AuthService {
     if (error) {
       throw error;
     }
-    this.sessionSignal.set(null);
+    this.userStore.setSession(null);
   }
 }

--- a/src/app/shared/services/user-store.service.spec.ts
+++ b/src/app/shared/services/user-store.service.spec.ts
@@ -1,0 +1,105 @@
+import type { AuthSession } from '@supabase/supabase-js';
+
+import { UserStoreService } from './user-store.service';
+
+const baseSession = (overrides: Partial<AuthSession> = {}): AuthSession => ({
+  access_token: 'token',
+  expires_at: null,
+  expires_in: 3600,
+  refresh_token: 'refresh',
+  token_type: 'bearer',
+  provider_token: null,
+  provider_refresh_token: null,
+  user: {
+    id: 'user-1',
+    email: 'demo@example.com',
+    app_metadata: {},
+    user_metadata: {},
+    aud: 'authenticated',
+    created_at: '2024-01-01T00:00:00.000Z',
+    role: 'authenticated',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    identities: [],
+    last_sign_in_at: '2024-01-01T00:00:00.000Z',
+    factors: [],
+    phone: '',
+  },
+  ...overrides,
+});
+
+describe('UserStoreService', () => {
+  let service: UserStoreService;
+
+  beforeEach(() => {
+    service = new UserStoreService();
+  });
+
+  it('starts in a loading state', () => {
+    expect(service.snapshot.status).toBe('loading');
+    expect(service.snapshot.session).toBeNull();
+  });
+
+  it('stores an authenticated session and derives roles from metadata arrays', () => {
+    const session = baseSession({
+      user: {
+        ...baseSession().user,
+        app_metadata: { roles: ['admin', 'user'] },
+      },
+    });
+
+    service.setSession(session);
+
+    expect(service.snapshot.status).toBe('authenticated');
+    expect(service.snapshot.user).toEqual({ id: 'user-1', email: 'demo@example.com' });
+    expect(service.snapshot.roles).toEqual(['admin', 'user']);
+    expect(service.snapshot.error).toBeNull();
+  });
+
+  it('falls back to user metadata roles when app metadata is unavailable', () => {
+    const session = baseSession({
+      user: {
+        ...baseSession().user,
+        app_metadata: {},
+        user_metadata: { role: 'manager' },
+      },
+    });
+
+    service.setSession(session);
+
+    expect(service.snapshot.roles).toEqual(['manager']);
+  });
+
+  it('clears the session and roles when signing out', () => {
+    service.setSession(baseSession());
+    service.setSession(null);
+
+    expect(service.snapshot.status).toBe('unauthenticated');
+    expect(service.snapshot.session).toBeNull();
+    expect(service.snapshot.roles).toEqual([]);
+  });
+
+  it('tracks errors without mutating the current session', () => {
+    service.setSession(baseSession());
+    service.setError('Network down');
+
+    expect(service.snapshot.error).toBe('Network down');
+    expect(service.snapshot.status).toBe('authenticated');
+
+    service.clearError();
+
+    expect(service.snapshot.error).toBeNull();
+  });
+
+  it('verifies role requirements', () => {
+    service.setSession(baseSession({
+      user: {
+        ...baseSession().user,
+        app_metadata: { roles: ['admin'] },
+      },
+    }));
+
+    expect(service.hasRequiredRole(['admin'])).toBe(true);
+    expect(service.hasRequiredRole(['user'])).toBe(false);
+    expect(service.hasRequiredRole(undefined)).toBe(true);
+  });
+});

--- a/src/app/shared/services/user-store.service.ts
+++ b/src/app/shared/services/user-store.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import type { AuthSession } from '@supabase/supabase-js';
+
+type Session = AuthSession;
+
+export type AuthStatus = 'loading' | 'authenticated' | 'unauthenticated';
+
+export interface AuthUserSummary {
+  id: string;
+  email?: string;
+}
+
+export interface AuthState {
+  status: AuthStatus;
+  session: Session | null;
+  user: AuthUserSummary | null;
+  roles: readonly string[];
+  error: string | null;
+}
+
+const INITIAL_STATE: AuthState = {
+  status: 'loading',
+  session: null,
+  user: null,
+  roles: [],
+  error: null,
+};
+
+@Injectable({ providedIn: 'root' })
+export class UserStoreService {
+  private readonly stateSubject = new BehaviorSubject<AuthState>(INITIAL_STATE);
+
+  readonly state$: Observable<AuthState> = this.stateSubject.asObservable();
+
+  get snapshot(): AuthState {
+    return this.stateSubject.getValue();
+  }
+
+  setLoading(): void {
+    const current = this.snapshot;
+    this.stateSubject.next({
+      ...current,
+      status: 'loading',
+    });
+  }
+
+  setSession(session: Session | null): void {
+    if (!session) {
+      this.stateSubject.next({
+        status: 'unauthenticated',
+        session: null,
+        user: null,
+        roles: [],
+        error: null,
+      });
+      return;
+    }
+
+    const roles = this.extractRoles(session);
+    this.stateSubject.next({
+      status: 'authenticated',
+      session,
+      user: {
+        id: session.user.id,
+        email: session.user.email ?? undefined,
+      },
+      roles,
+      error: null,
+    });
+  }
+
+  setError(error: string): void {
+    const current = this.snapshot;
+    this.stateSubject.next({
+      ...current,
+      error,
+    });
+  }
+
+  clearError(): void {
+    const current = this.snapshot;
+    if (!current.error) {
+      return;
+    }
+
+    this.stateSubject.next({
+      ...current,
+      error: null,
+    });
+  }
+
+  hasRequiredRole(roles: readonly string[] | undefined): boolean {
+    if (!roles || roles.length === 0) {
+      return true;
+    }
+
+    const currentRoles = this.snapshot.roles;
+    if (!currentRoles || currentRoles.length === 0) {
+      return false;
+    }
+
+    return roles.some(role => currentRoles.includes(role));
+  }
+
+  private extractRoles(session: Session): readonly string[] {
+    const fromAppMetadata = session.user.app_metadata?.['roles'];
+    if (Array.isArray(fromAppMetadata)) {
+      return fromAppMetadata.filter((role): role is string => typeof role === 'string');
+    }
+
+    const singleAppRole = session.user.app_metadata?.['role'];
+    if (typeof singleAppRole === 'string') {
+      return [singleAppRole];
+    }
+
+    const userMetaRole = session.user.user_metadata?.['role'];
+    if (typeof userMetaRole === 'string') {
+      return [userMetaRole];
+    }
+
+    const userMetaRoles = session.user.user_metadata?.['roles'];
+    if (Array.isArray(userMetaRoles)) {
+      return userMetaRoles.filter((role): role is string => typeof role === 'string');
+    }
+
+    return [];
+  }
+}

--- a/src/testing/supabase-js.mock.ts
+++ b/src/testing/supabase-js.mock.ts
@@ -1,3 +1,25 @@
+export type AuthUser = {
+  id: string;
+  email?: string | null;
+  app_metadata?: Record<string, unknown>;
+  user_metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export interface AuthSession {
+  user: AuthUser;
+  [key: string]: unknown;
+}
+
+export type AuthChangeEvent =
+  | 'SIGNED_IN'
+  | 'SIGNED_OUT'
+  | 'TOKEN_REFRESHED'
+  | 'USER_UPDATED'
+  | 'PASSWORD_RECOVERY';
+
+export type Session = AuthSession;
+
 export type SupabaseClient = any;
 
 export const createClient = (


### PR DESCRIPTION
## Summary
- add a user store service for Supabase session state and wire it through the auth service
- update the application shell and navigation to react to authentication status and role-aware routing
- introduce an auth guard plus comprehensive unit tests for login, navbar, auth service, guard, and session store

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dd6c2780e08324a26f1a942286dd96