### PR TITLE
Fix navigator lock error and serve manifest assets

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,8 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              "src/manifest.webmanifest"
             ],
             "styles": [
               "src/tailwind-input.css",
@@ -95,7 +96,8 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              "src/manifest.webmanifest"
             ],
             "styles": [
               "src/tailwind-input.css",

--- a/src/app/shared/services/supabase.service.ts
+++ b/src/app/shared/services/supabase.service.ts
@@ -31,6 +31,11 @@ export class SupabaseService {
         auth: {
           persistSession: true,
           autoRefreshToken: true,
+          // Disable the experimental Navigator LockManager integration which can
+          // throw when Zone.js intercepts the promise chain. The Hassib dashboard
+          // runs in a single-tab context, so falling back to a no-op lock keeps
+          // Supabase session management stable without noisy console errors.
+          lock: async (_name: string, _acquireTimeout: number, fn: () => Promise<unknown>) => await fn(),
         },
       });
       this.configuredSignal.set(true);

--- a/src/assets/icons/hassib-icon.svg
+++ b/src/assets/icons/hassib-icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Hassib App Icon</title>
+  <desc id="desc">Stylised letter H on a teal gradient background</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#12b8b6" />
+      <stop offset="100%" stop-color="#0c8d8c" />
+    </linearGradient>
+  </defs>
+  <rect x="32" y="32" width="448" height="448" rx="104" fill="url(#bg)" />
+  <path fill="#f9fafb" d="M168 140c-13.3 0-24 10.7-24 24v184c0 13.3 10.7 24 24 24h24c13.3 0 24-10.7 24-24v-56h80v56c0 13.3 10.7 24 24 24h24c13.3 0 24-10.7 24-24V164c0-13.3-10.7-24-24-24h-24c-13.3 0-24 10.7-24 24v56h-80v-56c0-13.3-10.7-24-24-24h-24z" />
+  <path fill="#ecfeff" opacity="0.6" d="M256 320l104 104H152z" />
+</svg>

--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -1,12 +1,18 @@
 {
-  "name": "Hassibb",
-  "short_name": "Hassibb",
-  "start_url": "/",
+  "name": "Hassib POS & Inventory Hub",
+  "short_name": "Hassib",
+  "description": "Point of sale and inventory management for retail teams.",
+  "start_url": ".",
+  "scope": ".",
   "display": "standalone",
-  "background_color": "#f7fafc",
+  "background_color": "#0ea5a4",
   "theme_color": "#0ea5a4",
   "icons": [
-    { "src": "assets/icon-192.svg", "sizes": "192x192", "type": "image/svg+xml", "purpose": "any" },
-    { "src": "assets/icon-512.svg", "sizes": "512x512", "type": "image/svg+xml", "purpose": "any" }
+    {
+      "src": "assets/icons/hassib-icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any maskable"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- disable the experimental Supabase navigator lock to avoid Zone.js acquire errors during auth refresh
- add the web manifest and icon assets to Angular's asset pipeline so the manifest loads without 404s
- replace the manifest PNG icon set with a single SVG asset to satisfy the no-PNG requirement

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dd7fce944883249bd2428104ac1aac