### PR TITLE
Add missing Supabase user scoping migration

### DIFF
--- a/SUPABASE.md
+++ b/SUPABASE.md
@@ -155,6 +155,12 @@ Enable RLS on the tables so that only authenticated users can access them. The f
 provide the minimal permissions required by the application (read and write for authenticated
 users). Add stricter checks if you implement multi-tenant separation.
 
+> **Heads up:** the Angular services scope every request by the authenticated user's id. The
+> repository contains a migration (`supabase/migrations/20240504120000_add_user_id_and_rls.sql`)
+> that adds the required `user_id` columns, indexes and RLS policies. Apply it with
+> `supabase db push` (or copy the statements into the SQL editor) before using the app, otherwise
+> Supabase will reject the queries because the `user_id` columns do not exist.
+
 ```sql
 alter table public.inventory_items enable row level security;
 alter table public.sales_lines enable row level security;

--- a/supabase/migrations/20240504120000_add_user_id_and_rls.sql
+++ b/supabase/migrations/20240504120000_add_user_id_and_rls.sql
@@ -1,1 +1,86 @@
- 
+-- Ensure multi-tenant columns exist so that the Angular application can scope queries
+-- by the authenticated Supabase user. The app already sends the user id with every
+-- insert/update, but the original migration file was empty which meant the required
+-- columns and row level security policies were never applied.
+
+begin;
+
+-- Storage locations --------------------------------------------------------
+alter table if exists public.storage_locations
+  add column if not exists user_id uuid references auth.users (id) on delete cascade;
+
+create index if not exists idx_storage_locations_user_id
+  on public.storage_locations (user_id);
+
+alter table if exists public.storage_locations enable row level security;
+
+create policy if not exists "Storage locations are scoped per user"
+  on public.storage_locations
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Inventory ----------------------------------------------------------------
+alter table if exists public.inventory_items
+  add column if not exists user_id uuid references auth.users (id) on delete cascade;
+
+create index if not exists idx_inventory_items_user_id
+  on public.inventory_items (user_id);
+
+create index if not exists idx_inventory_items_user_sku
+  on public.inventory_items (user_id, sku);
+
+alter table if exists public.inventory_items enable row level security;
+
+create policy if not exists "Inventory is scoped per user"
+  on public.inventory_items
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Inventory movements ------------------------------------------------------
+alter table if exists public.inventory_movements
+  add column if not exists user_id uuid references auth.users (id) on delete cascade;
+
+create index if not exists idx_inventory_movements_user_id
+  on public.inventory_movements (user_id);
+
+alter table if exists public.inventory_movements enable row level security;
+
+create policy if not exists "Inventory movements are scoped per user"
+  on public.inventory_movements
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Sales orders -------------------------------------------------------------
+alter table if exists public.sales_orders
+  add column if not exists user_id uuid references auth.users (id) on delete cascade;
+
+create index if not exists idx_sales_orders_user_id
+  on public.sales_orders (user_id);
+
+alter table if exists public.sales_orders enable row level security;
+
+create policy if not exists "Sales orders are scoped per user"
+  on public.sales_orders
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+-- Sales lines --------------------------------------------------------------
+alter table if exists public.sales_lines
+  add column if not exists user_id uuid references auth.users (id) on delete cascade;
+
+create index if not exists idx_sales_lines_user_id
+  on public.sales_lines (user_id);
+
+alter table if exists public.sales_lines enable row level security;
+
+create policy if not exists "Sales lines are scoped per user"
+  on public.sales_lines
+  for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);
+
+commit;


### PR DESCRIPTION
## Summary
- populate the previously empty Supabase migration with the user_id columns, indexes, and RLS policies required by the Angular app
- document that the migration must be applied so Supabase stops rejecting queries that reference user_id

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e378421a50832497065371fbf10680